### PR TITLE
Unset cookie breaks superagent

### DIFF
--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -23,7 +23,9 @@ export default class ApiClient {
               request.query(options.params);
             }
             if (__SERVER__) {
-              request.set('cookie', req.get('cookie'));
+              if(req.get('cookie')){
+                request.set('cookie', req.get('cookie'));
+              }
             }
             if (options && options.data) {
               request.send(options.data);


### PR DESCRIPTION
If the request has no cookie, superagent breaks (setting a header to `undefined`) which results in the signup page not loading, as well as the application not being isomorphic, since the data is not fetched and rendered on the server-side.