### PR TITLE
[POC] Server-side CSS

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -2,7 +2,7 @@ import Express from 'express';
 import React from 'react';
 import Router from 'react-router';
 import Location from 'react-router/lib/Location';
-import routes from './views/routes';
+import routes from './server-routes.bundle';
 import config from './config';
 import favicon from 'serve-favicon';
 import compression from 'compression';

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -3,54 +3,97 @@ var webpack = require('webpack');
 var writeStats = require('./utils/writeStats');
 var notifyStats = require('./utils/notifyStats');
 var assetsPath = path.resolve(__dirname, '../static/dist');
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
+// var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var host = 'localhost';
 var port = parseInt(process.env.PORT) + 1 || 3001;
 
+var publicPath = 'http://' + host + ':' + port + '/dist/';
+var commonLoaders = [{
+  test: /\.(jpe?g|png|gif|svg)$/,
+  loader: 'file'
+}];
+
 module.exports = {
-  devtool: 'eval-source-map',
-  context: path.resolve(__dirname, '..'),
-  entry: {
-    'main': [
-      'webpack-dev-server/client?http://' + host + ':' + port,
-      'webpack/hot/only-dev-server',
-      './src/client.js'
-    ]
-  },
-  output: {
-    path: assetsPath,
-    filename: '[name]-[hash].js',
-    chunkFilename: '[name]-[chunkhash].js',
-    publicPath: 'http://' + host + ':' + port + '/dist/'
-  },
-  module: {
-    loaders: [
-      { test: /\.(jpe?g|png|gif|svg)$/, loader: 'file' },
-      { test: /\.js$/, exclude: /node_modules/, loaders: ['react-hot', 'babel?stage=0&optional=runtime&plugins=typecheck']},
-      { test: /\.scss$/, loader: 'style!css!autoprefixer?browsers=last 2 version!sass?outputStyle=expanded&sourceMap=true&sourceMapContents=true' }
-    ]
-  },
-  progress: true,
-  resolve: {
-    modulesDirectories: [
-      'src',
-      'node_modules'
-    ],
-    extensions: ['', '.json', '.js']
-  },
-  plugins: [
-
-    // hot reload
-    new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin(),
-    new webpack.DefinePlugin({__CLIENT__: true, __SERVER__: false}),
-
-    // stats
-    function () {
-      this.plugin('done', notifyStats);
+  browser: {
+    name: 'browser bundle',
+    devtool: 'eval-source-map',
+    context: path.resolve(__dirname, '..'),
+    entry: {
+      'main': [
+        'webpack-dev-server/client?http://' + host + ':' + port,
+        'webpack/hot/only-dev-server',
+        './src/client.js'
+      ]
     },
-    function () {
-      this.plugin('done', writeStats);
-    }
-  ]
+    output: {
+      path: assetsPath,
+      filename: '[name]-[hash].js',
+      chunkFilename: '[name]-[chunkhash].js',
+      publicPath: publicPath
+    },
+    module: {
+      loaders: commonLoaders.concat([{
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loaders: ['react-hot', 'babel?stage=0&optional=runtime&plugins=typecheck']
+      }])
+    },
+    progress: true,
+    resolve: {
+      modulesDirectories: [
+        'src',
+        'node_modules'
+      ],
+      extensions: ['', '.json', '.js']
+    },
+    plugins: [
+
+      // hot reload
+      new webpack.HotModuleReplacementPlugin(),
+      new webpack.NoErrorsPlugin(),
+      new webpack.DefinePlugin({
+        __CLIENT__: true,
+        __SERVER__: false
+      }),
+
+      // stats
+      function() {
+        this.plugin('done', notifyStats);
+      },
+      function() {
+        this.plugin('done', writeStats);
+      }
+    ]
+  },
+
+  server: {
+    name: 'server bundle',
+    entry: './src/views/routes.js',
+    target: 'node',
+    bail: true,
+    output: {
+      path: __dirname,
+      filename: '../src/server-routes.bundle.js',
+      publicPath: publicPath,
+      libraryTarget: 'commonjs2'
+    },
+    externals: /^[a-z\-0-9]+$/,
+    module: {
+      loaders: commonLoaders.concat([{
+        test: /\.scss$/,
+        loader: 'css/locals!autoprefixer?browsers=last 2 version!sass?outputStyle=expanded&sourceMap=true&sourceMapContents=true'
+      }, {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loaders: ['babel?stage=0&optional=runtime&plugins=typecheck']
+      }])
+    },
+    plugins: [
+      new webpack.NoErrorsPlugin(),
+      new webpack.DefinePlugin({
+        __CLIENT__: false,
+        __SERVER__: true
+      })
+    ]
+  }
 };

--- a/webpack/webpack-dev-server.js
+++ b/webpack/webpack-dev-server.js
@@ -10,12 +10,19 @@ var WebpackDevServer = require('webpack-dev-server'),
     hot: true,
     inline: true,
     lazy: false,
-    publicPath: config.output.publicPath,
+    publicPath: config.browser.output.publicPath,
     headers: {"Access-Control-Allow-Origin": "*"},
     stats: {colors: true}
   },
-  compiler = webpack(config),
-  webpackDevServer = new WebpackDevServer(compiler, serverOptions);
+  browserCompiler = webpack(config.browser),
+  webpackDevServer = new WebpackDevServer(browserCompiler, serverOptions);
+
+var serverCompiler = webpack(config.server);
+serverCompiler.run(function(err) {
+  if (err) {
+    throw err;
+  }
+});
 
 webpackDevServer.listen(port, host, function() {
   console.info('==> 🚧  Webpack development server listening on %s:%s', host, port);


### PR DESCRIPTION
It doesn't work but some key points:

**Two webpack confgurations: one for the browser bundle, one for the server bundle**.
The browser bundle is pretty much identical, but the server bundle targets node.

**The server bundle uses `css-loader/locals`**
This [only outputs the identity names and does not inline the CSS](https://github.com/webpack/css-loader/blob/master/README.md#local-scope).
In my own project (from which this code is largely copied), I'm using css-modules which allows me to import in CSS files to React components and use specific class names:
```jsx
import styles from './styles.css';
<MyComponent classNames={styles.root}/>;
```

**The server pulls in a webpacked version of the routes file**
Node would fall over if it encountered a `require` call to a CSS file, but because webpack swaps that out for a hash of CSS class names to string identifiers, it doesn't.

**The dev server doesn't run**
This is because we're running `node ./babel.server` _before_ webpack has compiled the server routes file — so it's attempting to `import` the `server-routes.bunde.js` file before it exists. Other stuff probably doesn't work either.
In my project, I have a util that starts the server when in dev mode, which I call _after_ the server webpack compliation is done.

Apologies if I haven't explained it very well. I literally got my project working properly yesterday, so still grasping with all the concepts myself!

_Multi webpack config idea taken from [react-webpack-server-side-example](https://github.com/webpack/react-webpack-server-side-example/blob/master/webpack.config.js)._