### PR TITLE
Make it work on Windows 

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   ],
   "main": "babel.server.js",
   "scripts": {
-    "start": "NODE_PATH=\"./src\" NODE_ENV=\"production\" PORT=\"8080\" node ./babel.server",
+    "start": "SET NODE_PATH=./src && SET \"NODE_ENV=production\" && SET PORT=8080 && node ./babel.server",
     "build": "node ./node_modules/webpack/bin/webpack.js --verbose --colors --display-error-details --config webpack/prod.config.js",
     "lint": "node ./node_modules/eslint/bin/eslint.js -c .eslintrc src",
-    "start-dev": "NODE_PATH=\"./src\" NODE_ENV=\"development\" node ./babel.server",
-    "watch-client": "NODE_PATH=\"./src\" node webpack/webpack-dev-server.js",
+    "start-dev": "SET NODE_PATH=./src && SET \"NODE_ENV=development\" && node ./babel.server",
+    "watch-client": "SET NODE_PATH=./src && node webpack/webpack-dev-server.js",
     "dev": "node ./node_modules/concurrently/src/main.js --kill-others \"npm run watch-client\" \"npm run start-dev\""
   },
   "dependencies": {

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -1,6 +1,6 @@
 /*global __SERVER__*/
 import superagent from 'superagent';
-import config from 'config';
+import config from './config';
 
 function formatUrl(path) {
   let adjustedPath = path[0] !== '/' ? '/' + path : path;
@@ -12,7 +12,7 @@ function formatUrl(path) {
   return '/api' + adjustedPath;
 }
 
-export default class ApiClient {
+export default class {
   constructor(req) {
     ['get', 'post', 'put', 'patch', 'del'].
       forEach((method) => {

--- a/src/server.js
+++ b/src/server.js
@@ -13,6 +13,7 @@ import { Provider } from 'redux/react';
 import api from './api/api';
 import ApiClient from './ApiClient';
 const app = new Express();
+
 const proxy = httpProxy.createProxyServer({
   target: 'http://localhost:' + config.apiPort
 });

--- a/src/server.js
+++ b/src/server.js
@@ -13,7 +13,6 @@ import { Provider } from 'redux/react';
 import api from './api/api';
 import ApiClient from './ApiClient';
 const app = new Express();
-
 const proxy = httpProxy.createProxyServer({
   target: 'http://localhost:' + config.apiPort
 });

--- a/src/views/routes.js
+++ b/src/views/routes.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import {Route} from 'react-router';
-import App from 'views/App';
-import Home from 'views/Home';
-import SignUp from 'views/SignUp';
-import Login from 'views/Login';
+import App from './App';
+import Home from './Home';
+import SignUp from './SignUp';
+import Login from './Login';
 
 export default (
   <Route component={App}>


### PR DESCRIPTION
Hey,

I wanted to make it work on my Windows 8, it wasn't because of the NODE_PATH, here the fixes I did.
I don't know how to include that to make it work on both platforms at the same time, so don't merge it. I let you decide how to integrate it or just for people to find it.

You can see it's working as expected:

```
> npm run dev

> react-redux-universal-hot-example@0.0.1 dev C:\GitHub\react-redux-universal-hot-example
> node ./node_modules/concurrently/src/main.js --kill-others "npm run watch-client" "npm run start-dev"

[0]
[0] > react-redux-universal-hot-example@0.0.1 watch-client C:\GitHub\react-redux-universal-hot-example
[0] > SET NODE_PATH=./src && node webpack/webpack-dev-server.js
[0]
[1]
[1] > react-redux-universal-hot-example@0.0.1 start-dev C:\GitHub\react-redux-universal-hot-example
[1] > SET NODE_PATH=./src && SET "NODE_ENV=development" && node ./babel.server
[1]
[0] ==> �  Webpack development server listening on localhost:3001
[1] ==> ✅  Server is listening
[1] ==> �  React Redux Example Development running on port 3000, API on port 3030
[0] Hash: b7b9de4e9ea4bdd1b272
[0] Version: webpack 1.10.1
[0] Time: 4171ms
[0]                        Asset     Size  Chunks             Chunk Names
[0] main-b7b9de4e9ea4bdd1b272.js  2.85 MB       0  [emitted]  main
```

`run start` is working too.

What I needed to change:
- `SET` in the commands of `package.json` to set the environment variables (some embedded in " to avoid a trailing space)
- Fix few `require` paths that were not able to be resolved
- Remove the class name `ApiClient` other I got that for some reasons :
```ReferenceError: ApiClient is not defined
    at new ApiClient (C:/GitHub/react-redux-universal-hot-example/src/ApiClient.js:15:22)
    at C:/GitHub/react-redux-universal-hot-example/src/server.js:37:18```
