### PR TITLE
Update react-redux dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "piping": "0.1.8",
     "react": "0.13.3",
     "react-inline-css": "1.1.1",
-    "react-redux": "^1.0.0-alpha",
+    "react-redux": "0.2.2",
     "react-router": "v1.0.0-beta2",
     "redux": "1.0.0-rc",
     "serve-favicon": "^2.3.0",


### PR DESCRIPTION
Upon running `npm install` I received this warning:
```
npm WARN deprecated react-redux@1.0.0-alpha: OOPS! It wasn't a great idea to call it 1.0 alpha because we're still iterating on connector APIs. Please use 0.2.1 instead.
```

Updated react-redux to 0.2.2 in package.json.
