### PR TITLE
Expose params in universalRouter

### DIFF
--- a/src/universalRouter.js
+++ b/src/universalRouter.js
@@ -17,8 +17,8 @@ export function createTransitionHook(store) {
       })
       .map(getFetchData)
       .map(fetchData => {
-				if (routeParams !== {})
-					return fetchData(store, nextState.params);
+	if (routeParams !== {})
+	  return fetchData(store, nextState.params);
         return fetchData(store);
       }))
       .then(() => {

--- a/src/universalRouter.js
+++ b/src/universalRouter.js
@@ -9,7 +9,7 @@ const getFetchData = (component) => {
 
 export function createTransitionHook(store) {
   return (nextState, transition, callback) => {
-		const routeParams = nextState.params;
+    const routeParams = nextState.params;
     Promise.all(nextState.branch
       .map(route => route.component)
       .filter(component => {

--- a/src/universalRouter.js
+++ b/src/universalRouter.js
@@ -9,6 +9,7 @@ const getFetchData = (component) => {
 
 export function createTransitionHook(store) {
   return (nextState, transition, callback) => {
+		const routeParams = nextState.params;
     Promise.all(nextState.branch
       .map(route => route.component)
       .filter(component => {
@@ -16,6 +17,8 @@ export function createTransitionHook(store) {
       })
       .map(getFetchData)
       .map(fetchData => {
+				if (routeParams !== {})
+					return fetchData(store, nextState.params);
         return fetchData(store);
       }))
       .then(() => {


### PR DESCRIPTION
This adds in the url params so they can be used in a component's fetchData. Eg

```
static fetchData(store, params) {
    if (!isLoaded(store.getState())) {
      return store.dispatch(loadPodcast(params.id));
    }
  }
```

There might be a better way to do this so creating this PR mainly for reference.