### PR TITLE
Expose url params to API routes

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -16,10 +16,10 @@ app.use(bodyParser.json());
 export default function api() {
   return new Promise((resolve) => {
     app.use((req, res) => {
-      let matcher = /\/([^?]+)/.exec(req.url);
+      let matcher = req.url.split('/');
       let action = matcher && actions[matcher[1]];
       if (action) {
-        action(req)
+        action(req, matcher)
           .then((result) => {
             res.json(result);
           }, (reason) => {

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -19,7 +19,7 @@ export default function api() {
       let matcher = req.url.split('/');
       let action = matcher && actions[matcher[1]];
       if (action) {
-        action(req, matcher)
+        action(req, matcher.slice(2));
           .then((result) => {
             res.json(result);
           }, (reason) => {


### PR DESCRIPTION
Split on url fragments and pass to backend along with req to be handled as needed.

Eg, we can now branch to handle /item/123 -> Item.getOne(123)

```
'use strict';

import Podcast from '../models/Podcast';

export default function(req, matcher) {
	console.log(matcher);
	if (matcher[2]) {
		return new Promise((resolve, reject) => {
			Podcast.findById(matcher[2], function(err, result) {
             console.log(result)
				if (!err) {
					resolve(result);
				} else {
					reject(err);
				}
			});
		});
	} else {
		return new Promise((resolve, reject) => {
			Podcast.find({}).exec(function(err, result) {
				if (!err) {
					resolve(result);
				} else {
					reject(err);
				}
			});
		});
	}
}
```