### PR TITLE
Mask ApiClient into a variable - #14

### DIFF
--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -2,7 +2,7 @@
 import superagent from 'superagent';
 import config from 'config';
 
-class ApiClient {
+class ApiClient_ {
   constructor(req) {
     ['get', 'post', 'put', 'patch', 'del'].
       forEach((method) => {
@@ -32,6 +32,8 @@ class ApiClient {
       });
   }
 }
+
+let ApiClient = ApiClient_;
 
 function formatUrl(path) {
   let adjustedPath = path[0] !== '/' ? '/' + path : path;


### PR DESCRIPTION
This, for reasons unknown at the time of this commit, allows us to avoid the mysterious "ReferenceError: ApiClient is not defined" error that appears the first time you run "npm run dev" (or every time when run inside a docker container).