### PR TITLE
Clean `dist` folder before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "babel-eslint": "^3.1.18",
     "babel-loader": "5.1.3",
     "babel-runtime": "5.4.7",
+    "clean-webpack-plugin": "^0.1.3",
     "concurrently": "0.1.1",
     "css-loader": "^0.15.1",
     "eslint": "^0.23.0",

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -3,10 +3,12 @@
 var path = require('path');
 var webpack = require('webpack');
 var writeStats = require('./utils/writeStats');
+var CleanPlugin = require('clean-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var strip = require('strip-loader');
 
-var assetsPath = path.join(__dirname, '../static/dist');
+var relativeAssetsPath = '../static/dist';
+var assetsPath = path.join(__dirname, relativeAssetsPath);
 
 module.exports = {
   devtool: 'source-map',
@@ -37,6 +39,7 @@ module.exports = {
     extensions: ['', '.json', '.js']
   },
   plugins: [
+    new CleanPlugin([relativeAssetsPath]),
 
     // css files from the extract-text-plugin loader
     new ExtractTextPlugin('[name]-[chunkhash].css', {allChunks: true}),


### PR DESCRIPTION
When wanting to peak into the file contents of the files in `dist` directory to check if build changes work the way they're supposed to, i found that wading through tons of similar files, finding the ones with the current hash value was annoying.

This commit removes the `dist` folder whenever the `build` script is run.