### PR TITLE
Update the redux-devtools to v0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-redux": "0.2.2",
     "react-router": "v1.0.0-beta2",
     "redux": "1.0.0-rc",
-    "redux-devtools": "0.1.0",
+    "redux-devtools": "0.1.2",
     "serialize-javascript": "^1.0.0",
     "serve-favicon": "^2.3.0",
     "serve-static": "^1.10.0",


### PR DESCRIPTION
Update the redux-devtools to v0.1.2, which enables the "Ctrl + H" to hide the debug tool, better than switch off the `__DEVTOOLS__` variable. :)