### PR TITLE
Resolve the e.g.:"C:\"  issue on windows

### DIFF
--- a/src/universalRouter.js
+++ b/src/universalRouter.js
@@ -4,7 +4,8 @@ import routes from './views/routes';
 import { Provider } from 'react-redux';
 
 const getFetchData = (component) => {
-  return component.fetchData || (component.DecoratedComponent && component.DecoratedComponent.fetchData);
+  //need to check if the component is not undefined when using nested router without passing a component in props.
+  return  (component && component.fetchData) || (component && component.DecoratedComponent && component.DecoratedComponent.fetchData);
 };
 
 export function createTransitionHook(store) {

--- a/webpack/utils/writeStats.js
+++ b/webpack/utils/writeStats.js
@@ -46,6 +46,12 @@ module.exports = function writeStats(stats, env) {
     var name = path.resolve(__dirname, '../../', env === 'prod' ?
       m.name.slice('./src'.length) :
       m.name.slice(namePrefix.length + './src'.length));
+    //Resolve the e.g.:"C:\"  issue on windows
+    if(name) {
+      const i = name.indexOf(":");
+      name = name.substring(i > -1 ? i + 1 : 0, name.length + 1);
+    }
+    //end
     var regex = env === 'prod' ? /module\.exports = ((.|\n)+);/ : /exports\.locals = ((.|\n)+);/;
     var match = m.source.match(regex);
     cssModules[name] = match ? JSON.parse(match[1]) : {};


### PR DESCRIPTION
1. Current code won't work on windows, because the `path.resolve` will return the full path of windows like `C:\\example\\path` this will cause a 'undefined' error on window when loading the page.

2. Also need to fix another issue that if you are using an empty `Route` tag in your project like this.
```javascript

<Route>
    <Route path="/info-bar" component={Info}/>
    <Route component={App}>
      <Route path="/" component={Home}/>
      <Route path="/widgets" component={Widgets}/>
      <Route path="/about" component={About}/>
      <Route path="/login" component={Login}/>
      <Route path="/redirect" component={Redirect} onEnter={Redirect.onEnter}/>
      <Route path="*" component={NotFound}/>
    </Route>
  </Route>

```

So the component object needs to be checked before using it.