### PR TITLE
remove router transition hook when unmounting

### DIFF
--- a/src/views/App.js
+++ b/src/views/App.js
@@ -26,7 +26,13 @@ class App extends Component {
 
   componentWillMount() {
     const {router, store} = this.context;
-    router.addTransitionHook(createTransitionHook(store));
+    this.transitionHook = createTransitionHook(store);
+    router.addTransitionHook(this.transitionHook);
+  }
+
+  componentWillUnmount() {
+    const {router, store} = this.context;
+    router.removeTransitionHook(this.transitionHook);
   }
 
   handleLogout(event) {


### PR DESCRIPTION
Transition hook is being added every time the component is mounted so its gets called more and more times with every mount/unmount. Not a big deal in this component since it never unmounts, but a good example to follow for child components that do switch out.