### PR TITLE
Handle module build errors in SCSS files

### DIFF
--- a/webpack/utils/writeStats.js
+++ b/webpack/utils/writeStats.js
@@ -53,9 +53,11 @@ module.exports = function writeStats(stats, env) {
       }
     }
     //end
-    var regex = env === 'prod' ? /module\.exports = ((.|\n)+);/ : /exports\.locals = ((.|\n)+);/;
-    var match = m.source.match(regex);
-    cssModules[name] = match ? JSON.parse(match[1]) : {};
+    if (m.source) {
+      var regex = env === 'prod' ? /module\.exports = ((.|\n)+);/ : /exports\.locals = ((.|\n)+);/;
+      var match = m.source.match(regex);
+      cssModules[name] = match ? JSON.parse(match[1]) : {};
+    }
   });
 
   // Find compiled images in modules

--- a/webpack/webpack-dev-server.js
+++ b/webpack/webpack-dev-server.js
@@ -14,7 +14,11 @@ var WebpackDevServer = require('webpack-dev-server'),
     headers: {"Access-Control-Allow-Origin": "*"},
     stats: {colors: true}
   },
-  compiler = webpack(config),
+  compiler = webpack(config, function(err, stats){
+    var json = stats.toJson();
+    if (json.errors.length)
+      console.error(json.errors[0])
+  }),
   webpackDevServer = new WebpackDevServer(compiler, serverOptions);
 
 webpackDevServer.listen(port, host, function() {


### PR DESCRIPTION
This will log SCSS build errors rather than silently crashing the webpack watcher. 