### PR TITLE
Import babel polyfill to the client

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1,4 +1,5 @@
 /* global __DEVTOOLS__ */
+import 'babel/polyfill';
 import React from 'react';
 import BrowserHistory from 'react-router/lib/BrowserHistory';
 import Location from 'react-router/lib/Location';


### PR DESCRIPTION
This enable the `polyfill` for the browser support of the client side, but it will also increase a little bit size of the packed `main` JS file. 