### PR TITLE
Strip params in req.url for finding api action correctly

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -18,7 +18,7 @@ app.use(bodyParser.json());
 export default function api() {
   return new Promise((resolve) => {
     app.use((req, res) => {
-      let matcher = req.url.split('/');
+      let matcher = req.url.split('?')[0].split('/');
       let action = matcher && actions[matcher[1]];
       if (action) {
         action(req, matcher.slice(2))


### PR DESCRIPTION
look like #26 is still not solving. 
(remember? I asked a similar question on Slack few days ago. :smiley: )

when passing params in fetching data, 
generated `req.url` is like this: `/loadMessage?size=10&page=2`

```js
// src/api/api.js#L:21
let matcher = req.url.split('/'); // [], ['loadMessage?size=10&page=2']
let action = matcher && actions[matcher[1]] // 'loadMessage?size=10&page=2'

if (action) { // false, 404: NOT FOUND
...
```
 
so, we need to strip params in url for finding action correctly.
if you want use params in api action, can handle via `req.query`
```js
// src/api/routes/loadMessage.js
export default function(req) {
  return new Promise(resolve => {
    request.get('external-url')
      .query(req.query)
      .end(res => {
        resolve(res.body);
       });
  });
}
```