### PR TITLE
moves server to bin and extracts the babel compiler to a specific file

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -1,7 +1,9 @@
-require('babel/register')({
-  stage: 0,
-  plugins: ['typecheck']
-});
+#!/usr/bin/env node
+
+
+// enables ES6 support
+require('../compiler');
+
 
 /**
  * Define isomorphic constants.
@@ -20,4 +22,5 @@ if (__DEVELOPMENT__) {
   }
 }
 
-require('./src/server');
+
+require('../src/server');

--- a/compiler.js
+++ b/compiler.js
@@ -1,0 +1,5 @@
+// enables ES6 support
+require('babel/register')({
+  stage: 0,
+  plugins: ['typecheck']
+});

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "boilerplate",
     "babel"
   ],
-  "main": "babel.server.js",
+  "main": "lib/server.js",
   "scripts": {
     "start": "node ./node_modules/better-npm-run start",
     "build": "webpack --verbose --colors --display-error-details --config webpack/prod.config.js",
@@ -33,7 +33,7 @@
   },
   "betterScripts": {
     "start": {
-      "command": "node ./babel.server.js",
+      "command": "node ./bin/server.js",
       "env": {
         "NODE_PATH": "./src",
         "NODE_ENV": "production",
@@ -41,7 +41,7 @@
       }
     },
     "start-dev": {
-      "command": "node ./babel.server.js",
+      "command": "node ./bin/server.js",
       "env": {
         "NODE_PATH": "./src",
         "NODE_ENV": "development"


### PR DESCRIPTION
I think is a bit weird exist a babel server. Give me the impression it is a server to convert code. I usually prefer extract the babel compiler into a specific file and call it before starting the server. I also usually prefer keep the start point for the server in a bin folder. Seems like easier to find all the start points possible inside a specific folder for them.

These are just some preferences I have to organize my code. I will understand if you may prefer the previous way.

Great examples by the way.