### PR TITLE
Fix handling of query string in client bootstrap and universalRouter

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "lru-memoize": "0.0.2",
     "piping": "0.2.0",
     "pretty-error": "^1.1.2",
+    "query-string": "^2.4.0",
     "react": "0.13.3",
     "react-document-meta": "^0.1.4",
     "react-inline-css": "1.2.1",

--- a/src/client.js
+++ b/src/client.js
@@ -3,6 +3,7 @@ import 'babel/polyfill';
 import React from 'react';
 import BrowserHistory from 'react-router/lib/BrowserHistory';
 import Location from 'react-router/lib/Location';
+import queryString from 'query-string';
 import createStore from './redux/create';
 import ApiClient from './ApiClient';
 import universalRouter from './universalRouter';
@@ -11,7 +12,9 @@ const client = new ApiClient();
 
 const dest = document.getElementById('content');
 const store = createStore(client, window.__data);
-const location = new Location(document.location.pathname, document.location.search);
+const search = document.location.search;
+const query = search && queryString.parse(search);
+const location = new Location(document.location.pathname, query);
 universalRouter(location, history, store)
   .then(({component}) => {
     if (__DEVTOOLS__) {

--- a/src/universalRouter.js
+++ b/src/universalRouter.js
@@ -11,11 +11,12 @@ const getFetchData = (component = {}) => {
 
 export function createTransitionHook(store) {
   return (nextState, transition, callback) => {
+    const { params, location: { query } } = nextState;
     const promises = nextState.branch
       .map(route => route.component)                          // pull out individual route components
       .filter((component) => getFetchData(component))         // only look at ones with a static fetchData()
       .map(getFetchData)                                      // pull out fetch data methods
-      .map(fetchData => fetchData(store, nextState.params));  // call fetch data methods and save promises
+      .map(fetchData => fetchData(store, params, query || {}));  // call fetch data methods and save promises
     Promise.all(promises)
       .then(() => {
         callback(); // can't just pass callback to then() because callback assumes first param is error


### PR DESCRIPTION
This PR fixes an error in the client side bootstrap (src/client.js) whereby the document.location.search was not parsed into a query string object before creating a new Location object.  In addition it adds the route query string object to the universalRouter fetchData callback, in addition to the route params.