### PR TITLE
updateReactHotLoaderTo-1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "mocha": "^2.2.5",
     "node-sass": "^3.2.0",
     "react-a11y": "0.2.6",
-    "react-hot-loader": "1.2.8",
+    "react-hot-loader": "1.3.0",
     "redux-devtools": "1.0.2",
     "sass-loader": "^2.0.0",
     "strip-loader": "^0.1.0",


### PR DESCRIPTION
In reference to message from: @Dan Abramov

React Hot Loader 1.3.0 fixes a problem that caused `NoErrorsPlugin` to be necessary. In fact now errors thrown on module level shouldn't prevent future hot reloading of the same file after you fix the problem.

Could not find a reference to: `NoErrorsPlugin` as mentioned here:

Please update to RHL 1.3.0, and remove NoErrorsPlugin from Webpack configuration.
Thanks!