### PR TITLE
Fix for #188, widget field errors not displaying

### DIFF
--- a/src/components/WidgetForm/WidgetForm.js
+++ b/src/components/WidgetForm/WidgetForm.js
@@ -73,7 +73,7 @@ export default class WidgetForm extends Component {
           </button>
           <button className="btn btn-success"
                   onClick={handleSubmit(() => save(values)
-                    .catch(x => {
+                    .then(x => {
                       if (x && typeof x.error === 'object') {
                         return Promise.reject(x.error);
                       }


### PR DESCRIPTION
While I like the idea of `catch`, this fixes the problem. It makes sense if the actions are FSAs, since error better not be present if there's no error. Thoughts?

ref: #188