### PR TITLE
Support for Less files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This is a starter boiler plate app I've put together using the following technol
 * [ESLint](http://eslint.org) to maintain a consistent code style
 * [redux-form](https://github.com/erikras/redux-form) to manage form state in Redux
 * [lru-memoize](https://github.com/erikras/lru-memoize) to speed up form validation
-* [style-loader](https://github.com/webpack/style-loader) and [sass-loader](https://github.com/jtangelder/sass-loader) to allow import of stylesheets
+* [style-loader](https://github.com/webpack/style-loader), [sass-loader](https://github.com/jtangelder/sass-loader) and [less-loader](https://github.com/webpack/less-loader) to allow import of stylesheets in plain css, sass and less,
 * [react-document-meta](https://github.com/kodyl/react-document-meta) to manage title and meta tag information on both server and client
 * [webpack-isomorphic-tools](https://github.com/halt-hammerzeit/webpack-isomorphic-tools) to allow require() work for statics both on client and server
 * [mocha](https://mochajs.org/) to allow writing unit tests for the project.

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -26,6 +26,7 @@ module.exports = function (config) {
           { test: /\.(jpe?g|png|gif|svg)$/, loader: 'url', query: {limit: 10240} },
           { test: /\.js$/, exclude: /node_modules/, loaders: ['babel']},
           { test: /\.json$/, loader: 'json-loader' },
+          { test: /\.less$/, loader: 'style!css!less' },
           { test: /\.scss$/, loader: 'style!css?modules&importLoaders=2&sourceMap&localIdentName=[local]___[hash:base64:5]!autoprefixer?browsers=last 2 version!sass?outputStyle=expanded&sourceMap' }
         ]
       },

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "express-session": "^1.11.3",
     "file-loader": "^0.8.4",
     "http-proxy": "^1.11.1",
+    "less-loader": "^2.2.1",
     "lru-memoize": "1.0.0",
     "map-props": "^1.0.0",
     "piping": "0.2.0",

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -28,6 +28,7 @@ module.exports = {
     loaders: [
       { test: /\.js$/, exclude: /node_modules/, loaders: ['babel', 'eslint-loader']},
       { test: /\.json$/, loader: 'json-loader' },
+      { test: /\.less$/, loader: 'style!css!less' },
       { test: /\.scss$/, loader: 'style!css?modules&importLoaders=2&sourceMap&localIdentName=[local]___[hash:base64:5]!autoprefixer?browsers=last 2 version!sass?outputStyle=expanded&sourceMap' },
       { test: webpackIsomorphicToolsPlugin.regular_expression('images'), loader: 'url-loader?limit=10240' }
     ]

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -29,6 +29,7 @@ module.exports = {
     loaders: [
       { test: /\.js$/, exclude: /node_modules/, loaders: [strip.loader('debug'), 'babel']},
       { test: /\.json$/, loader: 'json-loader' },
+      { test: /\.less$/, loader: 'style!css!less' },
       { test: /\.scss$/, loader: ExtractTextPlugin.extract('style', 'css?modules&importLoaders=2&sourceMap!autoprefixer?browsers=last 2 version!sass?outputStyle=expanded&sourceMap=true&sourceMapContents=true') },
       { test: webpackIsomorphicToolsPlugin.regular_expression('images'), loader: 'url-loader?limit=10240' }
     ]

--- a/webpack/webpack-isomorphic-tools.js
+++ b/webpack/webpack-isomorphic-tools.js
@@ -17,7 +17,7 @@ module.exports = {
       parser: WebpackIsomorphicToolsPlugin.url_loader_parser
     },
     style_modules: {
-      extension: 'scss',
+      extensions: ['less','scss'],
       filter: function(m, regex, options, log) {
         if (!options.development) {
           return regex.test(m.name);


### PR DESCRIPTION
Added support for less file.
Sass is still used uniquely throughout the examples, but now is possible to require() .less files as well.


