### PR TITLE
rename react-transform-webpack-hmr

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "node-sass": "^3.2.0",
     "react-a11y": "0.2.6",
     "react-hot-loader": "1.3.0",
-    "react-transform-webpack-hmr": "^0.1.3",
+    "react-transform-hmr": "^0.1.3",
     "redux-devtools": "^2.1.2",
     "sass-loader": "^2.0.0",
     "strip-loader": "^0.1.0",


### PR DESCRIPTION
 react-transform-webpack-hmr has been renamed to react-transform-hmr.