### PR TITLE
Upgrade babel-plugin-react-transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "babel-core": "^5.8.22",
     "babel-eslint": "^4.0.10",
     "babel-loader": "5.3.2",
-    "babel-plugin-react-transform": "^1.0.2",
+    "babel-plugin-react-transform": "^1.1.1",
     "babel-runtime": "^5.8.24",
     "better-npm-run": "0.0.2",
     "chai": "^3.2.0",

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -22,9 +22,10 @@ try {
 
 babelLoaderQuery.plugins = babelLoaderQuery.plugins || [];
 babelLoaderQuery.plugins.push('react-transform');
-babelLoaderQuery.extra = {
-  'react-transform': [{
-    target: 'react-transform-hmr',
+babelLoaderQuery.extra = babelLoaderQuery.extra || {};
+babelLoaderQuery.extra['react-transform'] = {
+  transforms: [{
+    transform: 'react-transform-hmr',
     imports: ['react'],
     locals: ['module']
   }]


### PR DESCRIPTION
Fixes warning from new config format.

Also now respects `extra` properties that may already be set in `.babelrc`