### PR TITLE
update travis.yml builds to use node v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: node_js
+
 node_js:
   - "0.12"
-  - "0.11"
-  - "0.10"
-  - "iojs"
+  - "4.0"
+  - "4"
+
+sudo: false
+
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
travis builds [are passing](https://travis-ci.org/justingreenberg/react-redux-universal-hot-example) for node versions `0.12`, `4.0.0` and `4.1.1`. there is a good travis versioning explanation by @gergoerdosi on [hapijs#54](https://github.com/hapijs/contrib/issues/54).