### PR TITLE
Be specific about ignoring webpack-stat.json

### DIFF
--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -66,7 +66,7 @@ module.exports = {
   plugins: [
     // hot reload
     new webpack.HotModuleReplacementPlugin(),
-    new webpack.IgnorePlugin(/\.json$/),
+    new webpack.IgnorePlugin(/webpack-stats\.json$/),
     new webpack.DefinePlugin({
       __CLIENT__: true,
       __SERVER__: false,


### PR DESCRIPTION
This allows modules requiring .json to be properly packed, such as entities.