### PR TITLE
Workaround broken back/forward

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -52,9 +52,8 @@ const render = (loc, hist, str, preload) => {
     });
 };
 
-history.listenBefore((loc, callback) => {
-  render(loc, history, store, true)
-    .then((callback));
+history.listen((loc) => {
+  render(loc, history, store, true);
 });
 
 render(location, history, store);


### PR DESCRIPTION
https://github.com/erikras/react-redux-universal-hot-example/issues/240

This snuck in when I changed `history.listen` to `history.registerTransitionHook`.

So we're back to the URL updating synchronously before the transition. I'm unsure why the `listenBefore` isn't fired by browser history. Is it a bug or should it behave this way?

A more robust solution is required. I feel like it should be found in react-router's `useRoutes` but it will have to wait for a day or 2.

Apologies!