### PR TITLE
Fix back/forward properly

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -52,8 +52,11 @@ const render = (loc, hist, str, preload) => {
     });
 };
 
-history.listen((loc) => {
-  render(loc, history, store, true);
+history.listen(() => {});
+
+history.listenBefore((loc, callback) => {
+  render(loc, history, store, true)
+    .then((callback));
 });
 
 render(location, history, store);


### PR DESCRIPTION
Actually, here's a better fix that keeps the async hooks.

I'd definitely call this a bug in history.js, or a _very_ strange API.