### PR TITLE
Updated babel-plugin-typecheck to version 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "dependencies": {
     "babel": "5.8.23",
-    "babel-plugin-typecheck": "1.2.0",
+    "babel-plugin-typecheck": "1.3.0",
     "body-parser": "1.14.1",
     "compression": "1.5.2",
     "express": "4.13.3",


### PR DESCRIPTION
:rocket:

One of your dependencies has just updated, so this PR bumps the corresponding version number in your `package.json`.

You can now check that the dependency update doesn't break your code, and then release the new version of your software safe in the knowledge that it will stay in this working state, regardless of _when_ your users do `$ npm install`.

Have a good day!

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>