### PR TITLE
Updated webpack-isomorphic-tools to version 0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "socket.io-client": "1.3.7",
     "superagent": "1.4.0",
     "url-loader": "0.5.6",
-    "webpack-isomorphic-tools": "0.9.0"
+    "webpack-isomorphic-tools": "0.9.1"
   },
   "devDependencies": {
     "autoprefixer-loader": "^3.1.0",


### PR DESCRIPTION
:rocket:

webpack-isomorphic-tools just published version 0.9.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 7 commits (ahead by 7, behind by 0).

- [48533b5](https://github.com/halt-hammerzeit/webpack-isomorphic-tools/commit/48533b5db3d6864dc1f26d4d9fce67e9bd28aa07): version bump
- [5cc8948](https://github.com/halt-hammerzeit/webpack-isomorphic-tools/commit/5cc89488be6a36b1d8aa7d6c30b71cdbb093c28e): readme misc
- [8b0074d](https://github.com/halt-hammerzeit/webpack-isomorphic-tools/commit/8b0074dcd8c3f69e05e01b31d17405ea38ada82e): readme misc
- [4bc486a](https://github.com/halt-hammerzeit/webpack-isomorphic-tools/commit/4bc486a3190fd36a2ae8510d4930043ecb84f945): readme typo
- [59babb9](https://github.com/halt-hammerzeit/webpack-isomorphic-tools/commit/59babb944a4acec8eff5580cc9bab3fbd36eda02): readme typo
- [e22c6b2](https://github.com/halt-hammerzeit/webpack-isomorphic-tools/commit/e22c6b29890374b47b9c174545f677a0a68fdee3): misc
- [5bba42e](https://github.com/halt-hammerzeit/webpack-isomorphic-tools/commit/5bba42ebee32397a3a36c41731c7c3a8da35bef9): readme

See the [full diff](https://github.com/halt-hammerzeit/webpack-isomorphic-tools/compare/44daf4ec3270b9a5941915792eeb33732d0dd66e...48533b5db3d6864dc1f26d4d9fce67e9bd28aa07).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>