### PR TITLE
Stop calling render twice when devtools present

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -37,8 +37,9 @@ const location = createLocation(document.location.pathname, document.location.se
 const render = (loc, hist, str, preload) => {
   return universalRouter(loc, hist, str, preload)
     .then(({component}) => {
-      ReactDOM.render(component, dest);
-      if (__DEVTOOLS__) {
+      if (!__DEVTOOLS__) {
+        ReactDOM.render(component, dest);
+      } else {
         const { DevTools, DebugPanel, LogMonitor } = require('redux-devtools/lib/react');
         ReactDOM.render(<div>
           {component}


### PR DESCRIPTION
Render is currently called twice on the client in the event that _DEVTOOLS_ is true which was the source of some issues for me, here's a quick fix.