### PR TITLE
Updated react-redux to version 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "react-document-meta": "2.0.0-rc2",
     "react-dom": "0.14.0-rc1",
     "react-inline-css": "2.0.0",
-    "react-redux": "3.0.1",
+    "react-redux": "3.1.0",
     "react-router": "1.0.0-rc1",
     "redux": "3.0.1",
     "redux-form": "2.0.0",


### PR DESCRIPTION
:rocket:

react-redux just published version 3.1.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
[GitHub Release](https://github.com/rackt/react-redux/releases/tag/v3.1.0)

* Static methods are now hoisted and available on the connected component. The exact semantics are provided by [hoist-non-react-statics](https://github.com/mridgway/hoist-non-react-statics). (https://github.com/rackt/react-redux/issues/53, https://github.com/rackt/react-redux/issues/127)
* We removed usage of `Object.defineProperty` for IE8 support in the CommonJS build. We won't pledge to support IE8 forever but this was a low-hanging fruit. Note that UMD build still may have problems with IE8 because it uses `screw_ie8` option—if you really care, use CommonJS build and choose Uglify options yourself. (https://github.com/rackt/react-redux/pull/135, https://github.com/rackt/react-redux/issues/133)

---
The new version differs by 10 commits (ahead by 10, behind by 0).

- [f9dfe46](https://github.com/rackt/react-redux/commit/f9dfe461b730530c1a04061d6018540173efd5d1): 3.1.0
- [f7c9ac1](https://github.com/rackt/react-redux/commit/f7c9ac17c18fef310352d691c067310c2b3d524f): Style tweaks
- [441c359](https://github.com/rackt/react-redux/commit/441c359c8a02a8b00ed068d4e15e1cee258bb80c): Merge pull request #135 from mattydoincode/master
- [ef14a40](https://github.com/rackt/react-redux/commit/ef14a40e3d628115b3568aac2289cb6457e16cb7): Fixes CI
- [e2c7746](https://github.com/rackt/react-redux/commit/e2c7746612a3bf0ed7f7a4939776f491e2fbe8c0): Merge pull request #134 from djkirby/patch-1
- [251043d](https://github.com/rackt/react-redux/commit/251043ddf95bba3c4cbf5486cf2b392503cd4815): :memo: Fix typo in docs
- [4aba270](https://github.com/rackt/react-redux/commit/4aba27025f1ddd8b2aa5b6f4ffdb5bf55a39d479): clearer comment
- [0023d9f](https://github.com/rackt/react-redux/commit/0023d9f6cbd204e1f3dc9e1bc019caf50304a8b2): this should prevent ie8 from getting mad
- [2f7ec22](https://github.com/rackt/react-redux/commit/2f7ec22fbbf973ece5dd6af521516d00b54e69d7): Merge pull request #127 from erikras/master
- [5d7d448](https://github.com/rackt/react-redux/commit/5d7d44874e4b50a0da4ffc766dcfba7cf9e23941): added dependency on hoist-non-react-statics to allow connect() to hoist statics from wrapped component. fixes #53

See the [full diff](https://github.com/rackt/react-redux/compare/5c5f3880ce2a7637a208e7464907cc212306d3df...f9dfe461b730530c1a04061d6018540173efd5d1).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>