### PR TITLE
Fix path with query string on server

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -53,7 +53,7 @@ app.use((req, res) => {
   }
   const client = new ApiClient(req);
   const store = createStore(client);
-  const location = createHistory().createLocation(req.path, req.query);
+  const location = createHistory().createLocation(req.originalUrl);
 
   function hydrateOnClient() {
     res.send('<!doctype html>\n' +


### PR DESCRIPTION
The location was not getting the query string, this resolves the issue by passing the full path (with query string) as the first parameter.