### PR TITLE
Revert update of react-router

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "react-dom": "0.14.0-rc1",
     "react-inline-css": "2.0.0",
     "react-redux": "3.1.0",
-    "react-router": "1.0.0-rc2",
+    "react-router": "1.0.0-rc1",
     "redux": "3.0.1",
     "redux-form": "2.1.0",
     "serialize-javascript": "1.1.2",


### PR DESCRIPTION
When doing a fresh install after 7b7608ee6c3ccfdaa34f3f0326ff78a5e3f542ef, this error pops up: https://github.com/rackt/react-router/issues/2195

This is possibly caused by npm always [including the package called history in the tarballs](https://github.com/npm/npm/issues/9894).

I recommend downgrading react router for now.