### PR TITLE
Fixes TypeError when current route was undefined.

### DIFF
--- a/src/helpers/getStatusFromRoutes.js
+++ b/src/helpers/getStatusFromRoutes.js
@@ -1,5 +1,17 @@
-export default (routes) => {
-  return routes.reduce((prev, cur) => {
-    return cur.status || prev.status;
+/**
+ * Return the status code from the last matched route with a status property.
+ *
+ * @param matchedRoutes
+ * @returns {Number|undefined}
+ */
+export default (matchedRoutes) => {
+  return matchedRoutes.reduce((prev, cur) => {
+    if (cur && cur.status) {
+      return cur.status;
+    }
+
+    if (prev && prev.status) {
+      return prev.status;
+    }
   });
 };


### PR DESCRIPTION
@stevoland @erikras 
I encountered a bug with this when rendering server-side. `return cur.status || prev.status;` would error when `cur` was `undefined`.
That happens when no status properties are declared. I just rewrote the rest of it for my understanding, feel free to just take the fix.

Here's the original error:

```
[1] DATA FETCHING ERROR:   TypeError: Cannot read property 'status' of undefined
[1]
[1]   - getStatusFromRoutes.js:3
[1]     /Users/richard/tuts/js/react-redux-universal-hot-example/src/helpers/getStat    usFromRoutes.js:3:30
```