### PR TITLE
Include `getRoutes` in the store creation function on the client

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -16,7 +16,7 @@ import getRoutes from './routes';
 const client = new ApiClient();
 
 const dest = document.getElementById('content');
-const store = createStore(reduxReactRouter, null, createHistory, client, window.__data);
+const store = createStore(reduxReactRouter, getRoutes, createHistory, client, window.__data);
 
 function initSocket() {
   const socket = io('', {path: '/api/ws', transports: ['polling']});


### PR DESCRIPTION
Without this change I'm seeing a different list of components on the server vs. client (leading to different rendered markup). I'm not sure why the `getRoutes` was omitted on the client in the first place, but this seems to work fine. Without it, the first component in the router state is this object which is being added by redux-router here: https://github.com/rackt/redux-router/blob/b13e8b859f0733c77769102b7a9a76da00fe1249/src/routeReplacement.js#L43-L52