### PR TITLE
Allow onEnter hooks to load required data

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -12,11 +12,12 @@ import {Provider} from 'react-redux';
 import {reduxReactRouter, ReduxRouter} from 'redux-router';
 
 import getRoutes from './routes';
+import getRoutesWithoutHooks from './helpers/getRoutesWithoutHooks';
 
 const client = new ApiClient();
 
 const dest = document.getElementById('content');
-const store = createStore(reduxReactRouter, getRoutes, createHistory, client, window.__data);
+const store = createStore(reduxReactRouter, getRoutesWithoutHooks(getRoutes), createHistory, client, window.__data);
 
 function initSocket() {
   const socket = io('', {path: '/api/ws', transports: ['polling']});

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import { Link } from 'react-router';
+import { IndexLink, Link } from 'react-router';
 import { connect } from 'react-redux';
 import DocumentMeta from 'react-document-meta';
 import { isLoaded as isInfoLoaded, load as loadInfo } from 'redux/modules/info';
@@ -34,13 +34,17 @@ const meta = {
   }
 };
 
-const NavbarLink = ({to, children}) => (
-  <Link to={to} activeStyle={{
-    color: 'red'
-  }}>
-    {children}
-  </Link>
-);
+const NavbarLink = ({to, className, component, children}) => {
+  const Comp = component || Link;
+
+  return (
+    <Comp to={to} className={className} activeStyle={{
+      color: '#33e0ff'
+    }}>
+      {children}
+    </Comp>
+  );
+};
 
 @connect(
   state => ({user: state.auth.user}),
@@ -91,10 +95,10 @@ export default class App extends Component {
         <DocumentMeta {...meta}/>
         <nav className="navbar navbar-default navbar-fixed-top">
           <div className="container">
-            <Link to="/" className="navbar-brand">
+            <NavbarLink to="/" className="navbar-brand" component={IndexLink}>
               <div className={styles.brand}/>
               React Redux Example
-            </Link>
+            </NavbarLink>
 
             <ul className="nav navbar-nav">
               {user && <li><NavbarLink to="/chat">Chat</NavbarLink></li>}

--- a/src/helpers/__tests__/getRoutesWithoutHooks-test.js
+++ b/src/helpers/__tests__/getRoutesWithoutHooks-test.js
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import React from 'react';
+import { IndexRoute, Route } from 'react-router';
+import getRoutesWithoutHooks from '../getRoutesWithoutHooks';
+
+const noop = () => {};
+
+describe('getRoutesWithoutHooks', () => {
+
+  it('should work with JSX routes', () => {
+    const getRoutes = getRoutesWithoutHooks(() => {
+      return (
+        <Route path="/" >
+          <IndexRoute />
+          <Route path="1" />
+          <Route onEnter={noop}>
+            <Route path="2" />
+            <Route path="3" onEnter={noop}/>
+          </Route>
+        </Route>
+      );
+    });
+
+    expect(getRoutes()).to.deep.equal([
+      {
+        path: '/',
+        indexRoute: {},
+        childRoutes: [
+          {path: '1'},
+          {
+            childRoutes: [
+              {path: '2'},
+              {path: '3'}
+            ],
+          }
+        ]
+      }
+    ]);
+  });
+
+  it('should work with JS routes', () => {
+    const getRoutes = getRoutesWithoutHooks(() => {
+      return {
+        path: '/',
+        indexRoute: {},
+        onEnter: noop,
+        childRoutes: [
+          {path: '1'},
+          {
+            onEnter: noop,
+            childRoutes: [
+              {path: '2'},
+              {path: '3'}
+            ],
+          }
+        ]
+      };
+    });
+
+    expect(getRoutes()).to.deep.equal([
+      {
+        path: '/',
+        indexRoute: {},
+        childRoutes: [
+          {path: '1'},
+          {
+            childRoutes: [
+              {path: '2'},
+              {path: '3'}
+            ],
+          }
+        ]
+      }
+    ]);
+  });
+
+  it('should pass through store', () => {
+    const store = {};
+
+    const getRoutes = getRoutesWithoutHooks((_store) => {
+      expect(_store).to.equal(store);
+    });
+
+    getRoutes(store);
+  });
+});

--- a/src/helpers/getRoutesWithoutHooks.js
+++ b/src/helpers/getRoutesWithoutHooks.js
@@ -1,0 +1,19 @@
+import { createRoutes } from 'react-router/lib/RouteUtils';
+
+function removeHooks(routes) {
+  if (Array.isArray(routes)) {
+    return routes.map(removeHooks);
+  }
+
+  delete routes.onEnter;
+
+  if (routes.childRoutes) {
+    removeHooks(routes.childRoutes);
+  }
+
+  return routes;
+}
+
+export default function getRoutesWithoutHooks(_getRoutes) {
+  return (store) => removeHooks(createRoutes(_getRoutes(store)));
+}

--- a/src/redux/create.js
+++ b/src/redux/create.js
@@ -3,11 +3,7 @@ import createMiddleware from './middleware/clientMiddleware';
 import transitionMiddleware from './middleware/transitionMiddleware';
 
 export default function createStore(reduxReactRouter, getRoutes, createHistory, client, data) {
-  const middleware = [createMiddleware(client)];
-
-  if (__CLIENT__) {
-    middleware.push(transitionMiddleware);
-  }
+  const middleware = [createMiddleware(client), transitionMiddleware];
 
   let finalCreateStore;
   if (__DEVELOPMENT__ && __CLIENT__ && __DEVTOOLS__) {

--- a/src/redux/middleware/transitionMiddleware.js
+++ b/src/redux/middleware/transitionMiddleware.js
@@ -21,14 +21,15 @@ export default ({getState, dispatch}) => next => action => {
     } else {
       const {components, location, params} = action.payload;
       const promises = getDataDependencies(components, getState, dispatch, location, params);
+      const promise = Promise.all(promises)
+        .then(
+          () => next(action)
+        );
 
-      if (promises.length > 0) {
-        Promise.all(promises)
-          .then(
-            () => next(action)
-          );
-      } else {
-        next(action);
+      if (__SERVER__) {
+        // router state is null until ReduxRouter is created so we can use this to store
+        // our promise to let the server know when it can render
+        getState().router = promise;
       }
     }
   } else {

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import {Route} from 'react-router';
+import {IndexRoute, Route} from 'react-router';
+import { isLoaded as isAuthLoaded, load as loadAuth } from 'redux/modules/auth';
 import {
     App,
     Chat,
@@ -13,25 +14,34 @@ import {
   } from 'containers';
 
 export default (store) => {
-  const requireLogin = (nextState, replaceState) => {
-    const { auth: { user }} = store.getState();
-    if (!user) {
-      // oops, not logged in, so can't be here!
-      replaceState(null, '/');
+  const requireLogin = (nextState, replaceState, cb) => {
+    function checkAuth() {
+      const { auth: { user }} = store.getState();
+      if (!user) {
+        // oops, not logged in, so can't be here!
+        replaceState(null, '/');
+      }
+      cb();
+    }
+
+    if (!isAuthLoaded(store.getState())) {
+      store.dispatch(loadAuth()).then(checkAuth);
+    } else {
+      checkAuth();
     }
   };
 
   return (
-    <Route component={App}>
-      <Route path="/" component={Home}/>
-      <Route path="/widgets" component={Widgets}/>
-      <Route path="/about" component={About}/>
-      <Route path="/login" component={Login}/>
+    <Route path="/" component={App}>
+      <IndexRoute component={Home}/>
+      <Route path="widgets" component={Widgets}/>
+      <Route path="about" component={About}/>
+      <Route path="login" component={Login}/>
       <Route onEnter={requireLogin}>
-        <Route path="/chat" component={Chat}/>
-        <Route path="/loginSuccess" component={LoginSuccess}/>
+        <Route path="chat" component={Chat}/>
+        <Route path="loginSuccess" component={LoginSuccess}/>
       </Route>
-      <Route path="/survey" component={Survey}/>
+      <Route path="survey" component={Survey}/>
       <Route path="*" component={NotFound} status={404} />
     </Route>
   );

--- a/src/server.js
+++ b/src/server.js
@@ -8,7 +8,6 @@ import httpProxy from 'http-proxy';
 import path from 'path';
 import createStore from './redux/create';
 import ApiClient from './helpers/ApiClient';
-import getDataDependencies from './helpers/getDataDependencies';
 import Html from './helpers/Html';
 import PrettyError from 'pretty-error';
 import http from 'http';
@@ -93,19 +92,14 @@ app.use((req, res) => {
           routerState.location.query = qs.parse(routerState.location.search);
         }
 
-        Promise.all(getDataDependencies(
-          routerState.components,
-          store.getState,
-          store.dispatch,
-          routerState.location,
-          routerState.params
-        )).then(() => {
+        store.getState().router.then(() => {
           const component = (
             <Provider store={store} key="provider">
               <ReduxRouter/>
             </Provider>
           );
-          const status = getStatusFromRoutes(store.getState().router.routes);
+
+          const status = getStatusFromRoutes(routerState.routes);
           if (status) {
             res.status(status);
           }

--- a/src/server.js
+++ b/src/server.js
@@ -20,7 +20,6 @@ import {Provider} from 'react-redux';
 import qs from 'query-string';
 import getRoutes from './routes';
 import getStatusFromRoutes from './helpers/getStatusFromRoutes';
-import { load as loadAuth } from './redux/modules/auth';
 
 const pretty = new PrettyError();
 const app = new Express();
@@ -74,48 +73,43 @@ app.use((req, res) => {
     return;
   }
 
-  const afterAuth = () => {
-    store.dispatch(match(req.originalUrl, (error, redirectLocation, routerState) => {
-      if (redirectLocation) {
-        res.redirect(redirectLocation.pathname + redirectLocation.search);
-      } else if (error) {
-        console.error('ROUTER ERROR:', pretty.render(error));
-        res.status(500);
-        hydrateOnClient();
-      } else if (!routerState) {
-        res.status(500);
-        hydrateOnClient();
-      } else {
-        // Workaround redux-router query string issue:
-        // https://github.com/rackt/redux-router/issues/106
-        if (routerState.location.search && !routerState.location.query) {
-          routerState.location.query = qs.parse(routerState.location.search);
-        }
-
-        store.getState().router.then(() => {
-          const component = (
-            <Provider store={store} key="provider">
-              <ReduxRouter/>
-            </Provider>
-          );
-
-          const status = getStatusFromRoutes(routerState.routes);
-          if (status) {
-            res.status(status);
-          }
-          res.send('<!doctype html>\n' +
-            ReactDOM.renderToString(<Html assets={webpackIsomorphicTools.assets()} component={component}
-                                          store={store}/>));
-        }).catch((err) => {
-          console.error('DATA FETCHING ERROR:', pretty.render(err));
-          res.status(500);
-          hydrateOnClient();
-        });
+  store.dispatch(match(req.originalUrl, (error, redirectLocation, routerState) => {
+    if (redirectLocation) {
+      res.redirect(redirectLocation.pathname + redirectLocation.search);
+    } else if (error) {
+      console.error('ROUTER ERROR:', pretty.render(error));
+      res.status(500);
+      hydrateOnClient();
+    } else if (!routerState) {
+      res.status(500);
+      hydrateOnClient();
+    } else {
+      // Workaround redux-router query string issue:
+      // https://github.com/rackt/redux-router/issues/106
+      if (routerState.location.search && !routerState.location.query) {
+        routerState.location.query = qs.parse(routerState.location.search);
       }
-    }));
-  };
 
-  store.dispatch(loadAuth()).then(afterAuth, afterAuth);
+      store.getState().router.then(() => {
+        const component = (
+          <Provider store={store} key="provider">
+            <ReduxRouter/>
+          </Provider>
+        );
+
+        const status = getStatusFromRoutes(routerState.routes);
+        if (status) {
+          res.status(status);
+        }
+        res.send('<!doctype html>\n' +
+          ReactDOM.renderToString(<Html assets={webpackIsomorphicTools.assets()} component={component} store={store}/>));
+      }).catch((err) => {
+        console.error('DATA FETCHING ERROR:', pretty.render(err));
+        res.status(500);
+        hydrateOnClient();
+      });
+    }
+  }));
 });
 
 if (config.port) {


### PR DESCRIPTION
This should fix the `RequireLogin` hook and the issue with `IndexLink`s https://github.com/erikras/react-redux-universal-hot-example/pull/327

The routes passed to `createStore` are only used by redux-router to determine which routes are active - they don't require the onEnter hooks.