### PR TITLE
Update piping to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "lru-memoize": "1.0.0",
     "map-props": "1.0.0",
     "multireducer": "1.0.2",
-    "piping": "0.2.0",
+    "piping": "0.3.0",
     "pretty-error": "1.2.0",
     "query-string": "3.0.0",
     "react": "^0.14.0",


### PR DESCRIPTION
I was having problems with `piping` only reloading the API after every other file save, updating to 0.3.0 fixed it.

Changes: https://github.com/mdlawson/piping/compare/539f5d5c22715ac52893140a7c3a7e6194c8e16c...b9142fe37bdfb799eec7c8ed7c8d686ccd6f45a0