### PR TITLE
Remove unused dependency react-hot-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,6 @@
     "node-sass": "^3.3.3",
     "react-a11y": "^0.2.6",
     "react-addons-test-utils": "^0.14.0",
-    "react-hot-loader": "^1.3.0",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",
     "redbox-react": "^1.1.1",


### PR DESCRIPTION
Fixes #379.

Tested locally, and hot reloading works fine without it.