### PR TITLE
init clean up of ApiClient

### DIFF
--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -1,53 +1,33 @@
 import superagent from 'superagent';
 import config from '../config';
 
-/*
- * This silly underscore is here to avoid a mysterious "ReferenceError: ApiClient is not defined" error.
- * See Issue #14. https://github.com/erikras/react-redux-universal-hot-example/issues/14
- *
- * Remove it at your own risk.
- */
-class ApiClient_ {
-  constructor(req) {
-    ['get', 'post', 'put', 'patch', 'del'].
-      forEach((method) => {
-        this[method] = (path, options) => {
-          return new Promise((resolve, reject) => {
-            const request = superagent[method](this.formatUrl(path));
-            if (options && options.params) {
-              request.query(options.params);
-            }
-            if (__SERVER__) {
-              if (req.get('cookie')) {
-                request.set('cookie', req.get('cookie'));
-              }
-            }
-            if (options && options.data) {
-              request.send(options.data);
-            }
-            request.end((err, res) => {
-              if (err) {
-                reject((res && res.body) || err);
-              } else {
-                resolve(res.body);
-              }
-            });
-          });
-        };
-      });
-  }
+const methods = ['get', 'post', 'put', 'patch', 'del'];
 
-  /* This was originally a standalone function outside of this class, but babel kept breaking, and this fixes it  */
-  formatUrl(path) {
-    const adjustedPath = path[0] !== '/' ? '/' + path : path;
-    if (__SERVER__) {
-      // Prepend host and port of the API server to the path.
-      return 'http://localhost:' + config.apiPort + adjustedPath;
-    }
-    // Prepend `/api` to relative URL, to proxy to API server.
-    return '/api' + adjustedPath;
+function formatUrl(path) {
+  const adjustedPath = path[0] !== '/' ? '/' + path : path;
+  if (__SERVER__) {
+    // Prepend host and port of the API server to the path.
+    return 'http://localhost:' + config.apiPort + adjustedPath;
+  }
+  // Prepend `/api` to relative URL, to proxy to API server.
+  return '/api' + adjustedPath;
+}
+
+export default class ApiClient {
+  constructor(req) {
+    methods.forEach((method) =>
+      this[method] = (path, { params, data } = {}) => new Promise((resolve, reject) => {
+        const request = superagent[method](formatUrl(path));
+
+        if (params) request.query(params);
+
+        if (__SERVER__ && req.get('cookie')) {
+          request.set('cookie', req.get('cookie'));
+        }
+
+        if (data) request.send(data);
+
+        request.end((err, { body } = {}) => err ? reject(body || err) : resolve(body));
+      }));
   }
 }
-const ApiClient = ApiClient_;
-
-export default ApiClient;


### PR DESCRIPTION
The problems with babel appear to have been resolved. I could be missing something though. Also, refactored for cleaner/less code, but could be straying too far from the standard you've established. eg. if I know I want certain properties of a parameter, I give a default and destructure:
```js
request.end(err, { body } = {}) => ...
```
that way, we get undefined for body if the argument isn't provided and we don't have to do
```js
if(res && res.body) { ...
```
More apparent when pulling multiple props from an object, as in 'options'