### PR TITLE
Use ExtractTextPlugin as styleLoader for bootstrap-sass and font-awesome

### DIFF
--- a/src/theme/bootstrap.config.prod.js
+++ b/src/theme/bootstrap.config.prod.js
@@ -1,0 +1,5 @@
+var bootstrapConfig = require('./bootstrap.config.js');
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
+bootstrapConfig.styleLoader = ExtractTextPlugin.extract('style-loader', 'css-loader!sass-loader');
+module.exports = bootstrapConfig;
+

--- a/src/theme/bootstrap.config.prod.js
+++ b/src/theme/bootstrap.config.prod.js
@@ -1,5 +1,5 @@
-var bootstrapConfig = require('./bootstrap.config.js');
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
+const bootstrapConfig = require('./bootstrap.config.js');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
 bootstrapConfig.styleLoader = ExtractTextPlugin.extract('style-loader', 'css-loader!sass-loader');
 module.exports = bootstrapConfig;
 

--- a/src/theme/font-awesome.config.prod.js
+++ b/src/theme/font-awesome.config.prod.js
@@ -1,0 +1,5 @@
+var fontAwesomeConfig = require('./font-awesome.config.js');
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
+fontAwesomeConfig.styleLoader =  ExtractTextPlugin.extract('style-loader', 'css-loader!less-loader');
+module.exports = fontAwesomeConfig;
+

--- a/src/theme/font-awesome.config.prod.js
+++ b/src/theme/font-awesome.config.prod.js
@@ -1,5 +1,5 @@
-var fontAwesomeConfig = require('./font-awesome.config.js');
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
-fontAwesomeConfig.styleLoader =  ExtractTextPlugin.extract('style-loader', 'css-loader!less-loader');
+const fontAwesomeConfig = require('./font-awesome.config.js');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+fontAwesomeConfig.styleLoader = ExtractTextPlugin.extract('style-loader', 'css-loader!less-loader');
 module.exports = fontAwesomeConfig;
 

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -18,8 +18,8 @@ module.exports = {
   context: path.resolve(__dirname, '..'),
   entry: {
     'main': [
-      'bootstrap-sass!./src/theme/bootstrap.config.js',
-      'font-awesome-webpack!./src/theme/font-awesome.config.js',
+      'bootstrap-sass!./src/theme/bootstrap.config.prod.js',
+      'font-awesome-webpack!./src/theme/font-awesome.config.prod.js',
       './src/client.js'
     ]
   },


### PR DESCRIPTION
It seems that the integration of **bootstrap-sass** and **font-awesome** introduced some *Flash Of Unstyled Content* in the production build. Or rather no styling at all with javascript disabled.
Solution was to use the `ExtractTextPlugin` as style-loader for the loaders so that the final styling got appended to the main css file, rather than becoming a javascript rendered style tag.
Perhaps there exists better ways of having separate loader configurations for dev and prod, but this PR comes with two new files, allowing for more to things to be overridden if needed.
Works for me, but then I'm quite new to webpack :)