### PR TITLE
Fix path for files moved in Babel 6

### DIFF
--- a/server.babel.js
+++ b/server.babel.js
@@ -12,4 +12,4 @@ try {
   console.error(err);
 }
 
-require('babel/register')(config);
+require('babel-core/register')(config);

--- a/src/client.js
+++ b/src/client.js
@@ -1,7 +1,7 @@
 /**
  * THIS IS THE ENTRY POINT FOR THE CLIENT, JUST LIKE server.js IS THE ENTRY POINT FOR THE SERVER.
  */
-import 'babel/polyfill';
+import 'babel-core/polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import createHistory from 'history/lib/createBrowserHistory';


### PR DESCRIPTION
After pulling the change to upgrade Babel, I'm receiving these 2 errors running "npm run dev"

```
[1] Error: Cannot find module 'babel/register'
[1]     at Function.Module._resolveFilename (module.js:337:15)
[1]     at Function.Module._load (module.js:287:25)
[1]     at Module.require (module.js:366:17)
[1]     at require (module.js:385:17)
[1]     at Object.<anonymous> (/react-redux-universal-hot-example/server.babel.js:15:1)
[1]     at Module._compile (module.js:425:26)
[1]     at Object.Module._extensions..js (module.js:432:10)
[1]     at Module.load (module.js:356:32)
[1]     at Function.Module._load (module.js:311:12)
[1]     at Module.require (module.js:366:17)

[0] ./src/client.js
[0] Module not found: Error: Cannot resolve module 'babel-polyfill' in /react-redux-universal-hot-example/src
```

It appears those files have been moved to babel-core.