### PR TITLE
docs(general): update readme, add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing Guidelines
+
+Some basic conventions for this project.
+
+### General
+
+Please make sure that there aren't existing pull requests attempting to address the issue mentioned. Likewise, please check for issues related to update, as someone else may be working on the issue in a branch or fork.
+
+* Non-trivial changes should be discussed in an issue first
+* Develop in a topic branch, not master
+* Squash your commits
+
+### Linting
+
+Please check your code using `eslint` before submitting your pull requests, as the CI build will fail if `eslint` fails.
+
+### Commit Message Format
+
+Each commit message should include a **type**, a **scope** and a **subject**:
+
+```
+ <type>(<scope>): <subject>
+```
+
+Lines should not exceed 100 characters. This allows the message to be easier to read on github as well as in various git tools and produces a nice, neat commit log ie:
+
+```
+ #459  refactor(utils): create url mapper utility function
+ #463  chore(webpack): update to isomorphic tools v2
+ #494  fix(babel): correct dependencies and polyfills
+ #510  feat(app): add react-bootstrap responsive navbar
+``` 
+
+#### Type
+
+Must be one of the following:
+
+* **feat**: A new feature
+* **fix**: A bug fix
+* **docs**: Documentation only changes
+* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing
+  semi-colons, etc)
+* **refactor**: A code change that neither fixes a bug or adds a feature
+* **test**: Adding missing tests
+* **chore**: Changes to the build process or auxiliary tools and libraries such as documentation
+  generation
+
+#### Scope
+
+The scope could be anything specifying place of the commit change. For example `webpack`,
+`helpers`, `api` etc...
+
+#### Subject
+
+The subject contains succinct description of the change:
+
+* use the imperative, present tense: "change" not "changed" nor "changes"
+* don't capitalize first letter
+* no dot (.) at the end

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # React Redux Universal Hot Example
 
 [![build status](https://img.shields.io/travis/erikras/react-redux-universal-hot-example/master.svg?style=flat-square)](https://travis-ci.org/erikras/react-redux-universal-hot-example)
-[![react-redux-universal channel on discord](https://img.shields.io/badge/discord-react--redux--universal%40reactiflux-blue.svg)](https://discordapp.com/channels/102860784329052160/105739309289623552)
-[![Demo on Heroku](https://img.shields.io/badge/demo-heroku-lightgrey.png)](https://react-redux.herokuapp.com)
-[![Dependency Status](https://david-dm.org/erikras/react-redux-universal-hot-example.svg)](https://david-dm.org/erikras/react-redux-universal-hot-example)
-[![devDependency Status](https://david-dm.org/erikras/react-redux-universal-hot-example/dev-status.svg)](https://david-dm.org/erikras/react-redux-universal-hot-example#info=devDependencies)
-[![PayPal donate button](http://img.shields.io/paypal/donate.png?color=yellowgreen)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=E2LK57ZQ9YRMN)
+[![Dependency Status](https://david-dm.org/erikras/react-redux-universal-hot-example.svg?style=flat-square)](https://david-dm.org/erikras/react-redux-universal-hot-example)
+[![devDependency Status](https://david-dm.org/erikras/react-redux-universal-hot-example/dev-status.svg?style=flat-square)](https://david-dm.org/erikras/react-redux-universal-hot-example#info=devDependencies)
+[![react-redux-universal channel on discord](https://img.shields.io/badge/discord-react--redux--universal%40reactiflux-brightgreen.svg?style=flat-square)](https://discordapp.com/channels/102860784329052160/105739309289623552)
+[![Demo on Heroku](https://img.shields.io/badge/demo-heroku-brightgreen.svg?style=flat-square)](https://react-redux.herokuapp.com)
+[![PayPal donate button](https://img.shields.io/badge/donate-paypal-brightgreen.svg?style=flat-square)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=E2LK57ZQ9YRMN)
 
 ---
 
 ## About
 
-This is a starter boiler plate app I've put together using the following technologies:
+This is a starter boilerplate app I've put together using the following technologies:
 
 * ~~Isomorphic~~ [Universal](https://medium.com/@mjackson/universal-javascript-4761051b7ae9) rendering
 * Both client and server make calls to load data from separate API server
@@ -143,7 +143,7 @@ To run the tests in the project, just simply run `npm test` if you have `Chrome`
 
 To keep watching your test suites that you are working on, just set `singleRun: false` in the `karma.conf.js` file. Please be sure set it to `true` if you are running `npm test` on a continuous integration server (travis-ci, etc).
 
-## Heroku Deploy
+## Deployment on Heroku
 
 To get this project to work on Heroku, you need to:
 
@@ -155,11 +155,9 @@ To get this project to work on Heroku, you need to:
 
 The first deploy might take a while, but after that your `node_modules` dir should be cached.
 
-## The Future
-
-* [Inline Styles](docs/InlineStyles.md) - CSS is dead.
-
 ## FAQ
+
+This project moves fast and has an active community, so if you have a question that is not answered below please visit our [discord channel](https://discordapp.com/channels/102860784329052160/105739309289623552) or file an issue.
 
 #### Help! It doesn't work on Windows! What do I do?
 
@@ -169,6 +167,19 @@ Fear not. [chtefi](https://github.com/chtefi) has figured out [what needs to be 
 
 They will only show in development, but if you want to disable them even there, set `__DEVTOOLS__` to `false` in `/webpack/dev.config.js`.
 
+## Roadmap 
+
+Although this isn't a library, we recently started versioning to make it easier to track breaking changes and emerging best practices. 
+
+* [Babel 6](https://github.com/babel/babel) - Coming soon with v1 (see [#488](https://github.com/erikras/react-redux-universal-hot-example/issues/488))
+* [Inline Styles](docs/InlineStyles.md) - CSS is dead
+
+## Contributing
+
+I am more than happy to accept external contributions to the project in the form of feedback, bug reports and even better - pull requests :) 
+
+If you would like to submit a pull request, please make an effort to follow the guide in [CONTRIBUTING.md](contributing.md). 
+ 
 ---
 Thanks for checking this out.
 


### PR DESCRIPTION
you can check out these [changes to README on my fork](https://github.com/justingreenberg/react-redux-universal-hot-example)...
- update badges to consistent, flat style
- add basic roadmap section to readme
- add a contributing doc for discussion
- misc grammatical tweaks

note that david-dm badges are in warning state due to the major semver change in babel 6 and related dependencies—all badges will be nice and green after migration

sincerely,
your most pedantic contributor