### PR TITLE
feat(app): Improved scroll behavior for react-router

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "react-router-bootstrap": "^0.19.3",
     "redux": "^3.0.4",
     "redux-form": "^3.0.0",
+    "scroll-behavior": "^0.3.0",
     "serialize-javascript": "^1.1.2",
     "serve-favicon": "^2.3.0",
     "serve-static": "^1.10.0",

--- a/src/client.js
+++ b/src/client.js
@@ -5,6 +5,7 @@ import 'babel/polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import createHistory from 'history/lib/createBrowserHistory';
+import useScroll from 'scroll-behavior/lib/useStandardScroll';
 import createStore from './redux/create';
 import ApiClient from './helpers/ApiClient';
 import io from 'socket.io-client';
@@ -16,8 +17,12 @@ import makeRouteHooksSafe from './helpers/makeRouteHooksSafe';
 
 const client = new ApiClient();
 
+// Three differnt types of scroll behavior available.
+// Documented here: https://github.com/rackt/scroll-behavior
+const scrollablehistory = useScroll(createHistory);
+
 const dest = document.getElementById('content');
-const store = createStore(reduxReactRouter, makeRouteHooksSafe(getRoutes), createHistory, client, window.__data);
+const store = createStore(reduxReactRouter, makeRouteHooksSafe(getRoutes), scrollablehistory, client, window.__data);
 
 function initSocket() {
   const socket = io('', {path: '/api/ws', transports: ['polling']});

--- a/src/client.js
+++ b/src/client.js
@@ -17,7 +17,7 @@ import makeRouteHooksSafe from './helpers/makeRouteHooksSafe';
 
 const client = new ApiClient();
 
-// Three differnt types of scroll behavior available.
+// Three different types of scroll behavior available.
 // Documented here: https://github.com/rackt/scroll-behavior
 const scrollablehistory = useScroll(createHistory);
 


### PR DESCRIPTION
As outlined in #558, the default scroll behavior is a bit broken. For example, new pages do not automatically start at the top of the page if navigating from a page that has been scrolled. 

Use the [scroll behavior](https://github.com/rackt/scroll-behavior) package to aide in fixing this. 