### PR TITLE
remove serve-static explicit dependency as it is included already in express 4+

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "scroll-behavior": "^0.3.0",
     "serialize-javascript": "^1.1.2",
     "serve-favicon": "^2.3.0",
-    "serve-static": "^1.10.0",
     "socket.io": "^1.3.7",
     "socket.io-client": "^1.3.7",
     "superagent": "^1.4.0",

--- a/src/server.js
+++ b/src/server.js
@@ -32,7 +32,7 @@ const proxy = httpProxy.createProxyServer({
 app.use(compression());
 app.use(favicon(path.join(__dirname, '..', 'static', 'favicon.ico')));
 
-app.use(require('serve-static')(path.join(__dirname, '..', 'static')));
+app.use(Express.static(path.join(__dirname, '..', 'static')));
 
 // Proxy to API server
 app.use('/api', (req, res) => {


### PR DESCRIPTION
Starting from express 4, an explicit dependency on serve-static is not needed as a middleware based on that module is built-in.