### PR TITLE
require(babel/polyfill) is commented out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 webpack-assets.json
 webpack-stats.json
 npm-debug.log
+.project

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-require('babel/polyfill');
+// require('babel/polyfill');
 
 const environment = {
   development: {


### PR DESCRIPTION
/app/node_modules/babel/node_modules/babel-core/lib/polyfill.js:8
2015-11-18T04:47:22.761132+00:00 app[web.1]: [0] throw new Error("only one instance of babel/polyfill is allowed");

This error is prevented by commenting out the "require('babel/polyfill');" in "src/config.js (line 1)" while keeping "require('babel/polyfill');" in "src/client.js" (line 4).

