### PR TITLE
refactor(config): create meta from site info obj

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -9,31 +9,48 @@ const environment = {
   }
 }[process.env.NODE_ENV || 'development'];
 
+const siteInfo = {
+  author: {
+    twitter: '@erikras'
+  },
+  title: 'React Redux Example',
+  description: 'All the modern best practices in one example.',
+  logo: {
+    src: 'https://react-redux.herokuapp.com/logo.jpg',
+    height: 200,
+    width: 200
+  },
+  social: {
+    twitter: '@erikras'
+  }
+};
+
+function createMeta(info) {
+  return {
+    charSet: 'utf-8',
+    property: {
+      'og:site_name': info.title,
+      'og:image': info.logo.src,
+      'og:locale': 'en_US',
+      'og:title': info.title,
+      'og:description': info.description,
+      'twitter:card': 'summary',
+      'twitter:site': info.social.twitter,
+      'twitter:creator': info.author.twitter,
+      'twitter:title': info.title,
+      'twitter:description': info.description,
+      'twitter:image': info.logo.src,
+      'twitter:image:width': info.logo.width.toString(),
+      'twitter:image:height': info.logo.height.toString()
+    },
+  };
+}
+siteInfo.meta = createMeta(siteInfo);
+
 module.exports = Object.assign({
   host: process.env.HOST || 'localhost',
   port: process.env.PORT,
   apiHost: process.env.APIHOST || 'localhost',
   apiPort: process.env.APIPORT,
-  app: {
-    title: 'React Redux Example',
-    description: 'All the modern best practices in one example.',
-    meta: {
-      charSet: 'utf-8',
-      property: {
-        'og:site_name': 'React Redux Example',
-        'og:image': 'https://react-redux.herokuapp.com/logo.jpg',
-        'og:locale': 'en_US',
-        'og:title': 'React Redux Example',
-        'og:description': 'All the modern best practices in one example.',
-        'twitter:card': 'summary',
-        'twitter:site': '@erikras',
-        'twitter:creator': '@erikras',
-        'twitter:title': 'React Redux Example',
-        'twitter:description': 'All the modern best practices in one example.',
-        'twitter:image': 'https://react-redux.herokuapp.com/logo.jpg',
-        'twitter:image:width': '200',
-        'twitter:image:height': '200'
-      }
-    }
-  }
+  app: siteInfo
 }, environment);


### PR DESCRIPTION
The meta contains duplicate entries for properties like title and description. Splitting the information about the site into an object of pure data makes it a little easier to override/change site info and allows properties such as twitter username to be reused elsewhere.