### PR TITLE
fix(babel): remove babel hook

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -1,5 +1,3 @@
-require('../server.babel'); // babel registration (runtime transpilation for node)
-
 import express from 'express';
 import session from 'express-session';
 import bodyParser from 'body-parser';


### PR DESCRIPTION
It isn't necessary and pointless require the babel hook at the top. It's already required into the bin/api file and in addition it doesn't work because babel transpiles files required after the hook.