### PR TITLE
Fix for font-awesome icon animation and temporary fix for issue #588

### DIFF
--- a/src/redux/middleware/clientMiddleware.js
+++ b/src/redux/middleware/clientMiddleware.js
@@ -5,7 +5,7 @@ export default function clientMiddleware(client) {
         return action(dispatch, getState);
       }
 
-      const { promise, types, ...rest } = action;
+      const { promise, types, ...rest } = action; // eslint-disable-line no-redeclare
       if (!promise) {
         return next(action);
       }

--- a/src/theme/font-awesome.config.js
+++ b/src/theme/font-awesome.config.js
@@ -13,5 +13,6 @@ module.exports = {
     icons: true,
     larger: true,
     path: true,
+    animated: true,
   }
 };


### PR DESCRIPTION
Font-awesome-webpack was configured to exclude the animation part of font-awesome, which is needed in order to make the reload icon of the green "Reload Widgets" button spinning while reloading. 

Also, I added a local rule for eslint to temporary fix issue issue #588.

Best Regards,
Simon