### PR TITLE
docs(DevTools): documenting DevTool chrome extension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ In development, Redux Devtools are enabled by default. You can toggle visibility
 - <kbd>Ctrl+Q</kbd> Move Dock Position
 - see [redux-devtools-dock-monitor](https://github.com/gaearon/redux-devtools-dock-monitor) for more detail information.
 
+If you have the [Redux DevTools chrome extension](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd) installed it will automatically be used on the client-side instead.
+
 ## Building and Running Production Server
 
 ```bash


### PR DESCRIPTION
The DevTools chrome extension is pretty handy but the only references to its compatibility are in commit messages and the code itself. This just adds a note to the README letting people know that there is a Chrome extension out there for DevTools and that the app supports it