### PR TITLE
chore(eslint): re-enable block-scoped-var + padded-blocks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,10 +12,6 @@
     "import/namespace": 0,
     "import/no-unresolved": 0,
     "import/no-named-as-default": 2,
-    // Temporarirly disabled due to a possible bug in babel-eslint (todomvc example)
-    "block-scoped-var": 0,
-    // Temporarily disabled for test/* until babel/babel-eslint#33 is resolved
-    "padded-blocks": 0,
     "comma-dangle": 0,  // not sure why airbnb turned this on. gross!
     "indent": [2, 2, {"SwitchCase": 1}],
     "no-console": 0,

--- a/api/__tests__/api-test.js
+++ b/api/__tests__/api-test.js
@@ -2,7 +2,6 @@ import {expect} from 'chai';
 import {mapUrl} from '../utils/url';
 
 describe('mapUrl', () => {
-
   it('extracts nothing if both params are undefined', () => {
     expect(mapUrl(undefined, undefined)).to.deep.equal({
       action: null,
@@ -31,8 +30,8 @@ describe('mapUrl', () => {
       params: []
     });
   });
-  it('extracts the available actions and the params from an relative url string with GET params', () => {
 
+  it('extracts the available actions and the params from an relative url string with GET params', () => {
     const url = '/widget/load/param1/xzy?foo=bar';
     const splittedUrlPath = url.split('?')[0].split('/').slice(1);
     const availableActions = {a: 1, widget: {c: 1, load: () => 'baz'}};

--- a/api/api.js
+++ b/api/api.js
@@ -26,7 +26,6 @@ app.use(bodyParser.json());
 
 
 app.use((req, res) => {
-
   const splittedUrlPath = req.url.split('?')[0].split('/').slice(1);
 
   const {action, params} = mapUrl(actions, splittedUrlPath);
@@ -87,7 +86,6 @@ if (config.apiPort) {
     });
   });
   io.listen(runnable);
-
 } else {
   console.error('==>     ERROR: No PORT environment variable has been specified');
 }

--- a/api/utils/url.js
+++ b/api/utils/url.js
@@ -1,5 +1,4 @@
 export function mapUrl(availableActions = {}, url = []) {
-
   const notFound = {action: null, params: []};
 
   // test for empty input

--- a/src/components/__tests__/InfoBar-test.js
+++ b/src/components/__tests__/InfoBar-test.js
@@ -50,5 +50,4 @@ describe('InfoBar', () => {
     expect(styles.infoBar).to.be.a('string');
     expect(dom.className).to.include(styles.infoBar);
   });
-
 });

--- a/src/helpers/__tests__/getStatusFromRoutes-test.js
+++ b/src/helpers/__tests__/getStatusFromRoutes-test.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import getStatusFromRoutes from '../getStatusFromRoutes';
 
 describe('getStatusFromRoutes', () => {
-
   it('should return null when no routes have status code', () => {
     const status = getStatusFromRoutes([
         {}, {}

--- a/src/helpers/__tests__/makeRouteHooksSafe-test.js
+++ b/src/helpers/__tests__/makeRouteHooksSafe-test.js
@@ -5,7 +5,6 @@ import makeRouteHooksSafe from '../makeRouteHooksSafe';
 
 
 describe('makeRouteHooksSafe', () => {
-
   it('should work with JSX routes', () => {
     const onEnter = () => {
       throw new Error('Shouldn\'t call onEnter');

--- a/src/helpers/connectData.js
+++ b/src/helpers/connectData.js
@@ -8,7 +8,6 @@ import hoistStatics from 'hoist-non-react-statics';
 */
 
 export default function connectData(fetchData, fetchDataDeferred) {
-
   return function wrapWithFetchData(WrappedComponent) {
     class ConnectData extends Component {
       render() {

--- a/src/redux/middleware/transitionMiddleware.js
+++ b/src/redux/middleware/transitionMiddleware.js
@@ -11,7 +11,6 @@ export default ({getState, dispatch}) => next => action => {
 
     const {components, location, params} = action.payload;
     const promise = new Promise((resolve) => {
-
       const doTransition = () => {
         next(action);
         Promise.all(getDataDependencies(components, getState, dispatch, location, params, true))


### PR DESCRIPTION
Re-enabled these rules as it appears that the issues for both in babel/babel-eslint have been resolved.