### PR TITLE
chore(wallaby.js): add wallaby.js configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "strip-loader": "^0.1.0",
     "style-loader": "^0.13.0",
     "timekeeper": "0.0.5",
+    "wallaby-webpack": "0.0.10",
     "webpack": "^1.12.9",
     "webpack-dev-middleware": "^1.4.0",
     "webpack-hot-middleware": "^2.5.0"

--- a/wallaby.conf.js
+++ b/wallaby.conf.js
@@ -1,0 +1,65 @@
+'use strict';
+
+let babel = require('babel');
+let webpack = require('webpack');
+let wallabyWebpack = require('wallaby-webpack');
+
+module.exports = wallaby => {
+
+  let wallabyPostprocessor = wallabyWebpack({
+
+    resolve: {
+      modulesDirectories: ['src', 'node_modules'],
+      extensions: ['', '.json', '.js']
+    },
+
+    plugins: [
+      new webpack.DefinePlugin({
+        __CLIENT__: true,
+        __SERVER__: false,
+        __DEVELOPMENT__: true,
+        __DEVTOOLS__: false
+      }),
+
+      // if you'd like to use real sass loader instead of the mock,
+      // then because wallaby.js is using its own node.js version by default,
+      // you may need to run:
+      // `nvm install 4.2.2` or `nvm use 4.2.2`
+      // `npm rebuild node-sass`
+      new webpack.NormalModuleReplacementPlugin(/\.scss$/, result => {
+        let fs = require('fs');
+        let path = require('path');
+        let stylesMock = path.join(wallaby.projectCacheDir, 'stylesMock.js');
+        fs.writeFileSync(stylesMock, 'module.exports={infoBar: ""}');
+        result.request = stylesMock;
+      })
+    ]
+  });
+
+  return {
+    files: [
+      {pattern: 'node_modules/phantomjs-polyfill/bind-polyfill.js', instrument: false},
+      {pattern: 'src/**/*.+(js|json|less|scss)', load: false},
+      {pattern: 'src/**/*-test.js', ignore: true}
+    ],
+
+    tests: [
+      {pattern: 'src/**/*-test.js', load: false}
+    ],
+
+    compilers: {
+      '**/*.js*': wallaby.compilers.babel({
+        babel: babel,
+        stage: 0,
+        optional: 'runtime',
+        loose: 'all'
+      })
+    },
+
+    postprocessor: wallabyPostprocessor,
+
+    bootstrap: function () {
+      window.__moduleBundler.loadTests();
+    }
+  }
+};


### PR DESCRIPTION
As it [was suggested in wallaby repo](https://github.com/wallabyjs/public/issues/372), I have added wallaby.js configuration to the project. It allows those who use wallaby.js to have the pre-baked config for their real-time testing:

![wp](https://cloud.githubusercontent.com/assets/979966/11647518/9a15ce52-9db4-11e5-960a-8557b597c69d.gif)