### PR TITLE
#773 fix(react-helmet): Added a check for React-helmet's empty head

### DIFF
--- a/src/helpers/Html.js
+++ b/src/helpers/Html.js
@@ -27,11 +27,11 @@ export default class Html extends Component {
     return (
       <html lang="en-us">
         <head>
-          {head.base.toComponent()}
-          {head.title.toComponent()}
-          {head.meta.toComponent()}
-          {head.link.toComponent()}
-          {head.script.toComponent()}
+          {head && head.base.toComponent()}
+          {head && head.title.toComponent()}
+          {head && head.meta.toComponent()}
+          {head && head.link.toComponent()}
+          {head && head.script.toComponent()}
 
           <link rel="shortcut icon" href="/favicon.ico" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
Fix for the issue https://github.com/erikras/react-redux-universal-hot-example/issues/773. 

- Check for head won't be needed anymore once this PR https://github.com/nfl/react-helmet/pull/91 is merged. It will prevent getting undefined on `rewind()` call on the package level. 