### PR TITLE
fix(socket.io): Upgrade requests to use WebSockets

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -25,7 +25,7 @@ const dest = document.getElementById('content');
 const store = createStore(reduxReactRouter, makeRouteHooksSafe(getRoutes), scrollableHistory, client, window.__data);
 
 function initSocket() {
-  const socket = io('', {path: '/api/ws', transports: ['polling']});
+  const socket = io('', {path: '/ws'});
   socket.on('news', (data) => {
     console.log(data);
     socket.emit('my other event', { my: 'data from client' });


### PR DESCRIPTION
This PR enables socket.io to upgrade requests to use WebSockets (instead of polling), where possible.
Prior to this, socket.io used polling all the time and never upgraded the connection.

See https://github.com/nodejitsu/node-http-proxy#proxying-websockets.

Fixes #725.