### PR TITLE
clientMiddlevare - return original promise

### DIFF
--- a/src/redux/middleware/clientMiddleware.js
+++ b/src/redux/middleware/clientMiddleware.js
@@ -12,13 +12,17 @@ export default function clientMiddleware(client) {
 
       const [REQUEST, SUCCESS, FAILURE] = types;
       next({...rest, type: REQUEST});
-      return promise(client).then(
+      
+      const actionPromise = promise(client);
+      actionPromise.then(
         (result) => next({...rest, result, type: SUCCESS}),
         (error) => next({...rest, error, type: FAILURE})
       ).catch((error)=> {
         console.error('MIDDLEWARE ERROR:', error);
         next({...rest, error, type: FAILURE});
       });
+      
+      return actionPromise;
     };
   };
 }

--- a/src/redux/middleware/clientMiddleware.js
+++ b/src/redux/middleware/clientMiddleware.js
@@ -12,7 +12,7 @@ export default function clientMiddleware(client) {
 
       const [REQUEST, SUCCESS, FAILURE] = types;
       next({...rest, type: REQUEST});
-      
+
       const actionPromise = promise(client);
       actionPromise.then(
         (result) => next({...rest, result, type: SUCCESS}),
@@ -21,7 +21,7 @@ export default function clientMiddleware(client) {
         console.error('MIDDLEWARE ERROR:', error);
         next({...rest, error, type: FAILURE});
       });
-      
+
       return actionPromise;
     };
   };


### PR DESCRIPTION
It's better to return original promise in this case to my mind, because in component when we call action, the promise that this action will return will never reject.
