### PR TITLE
hoist-non-react-statics no longer needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "express-session": "^1.12.1",
     "history": "1.17.0",
     "file-loader": "^0.8.5",
-    "hoist-non-react-statics": "^1.0.3",
     "http-proxy": "^1.12.0",
     "invariant": "^2.2.0",
     "less": "^2.5.3",

--- a/src/helpers/connectData.js
+++ b/src/helpers/connectData.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import hoistStatics from 'hoist-non-react-statics';
 
 /*
   Note:
@@ -10,14 +9,15 @@ import hoistStatics from 'hoist-non-react-statics';
 export default function connectData(fetchData, fetchDataDeferred) {
   return function wrapWithFetchData(WrappedComponent) {
     class ConnectData extends Component {
+
+      static fetchData = fetchData;
+      static fetchDataDeferred = fetchDataDeferred;
+
       render() {
         return <WrappedComponent {...this.props} />;
       }
     }
 
-    ConnectData.fetchData = fetchData;
-    ConnectData.fetchDataDeferred = fetchDataDeferred;
-
-    return hoistStatics(ConnectData, WrappedComponent);
+    return ConnectData;
   };
 }


### PR DESCRIPTION
Since babel stage-0 has got `babel-plugin-transform-class-properties` we no longer need this npm package