### PR TITLE
refactor(webpack): relax module loader regex test

### DIFF
--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -68,11 +68,10 @@ module.exports = {
       { test: /\.json$/, loader: 'json-loader' },
       { test: /\.less$/, loader: 'style!css?modules&importLoaders=2&sourceMap&localIdentName=[local]___[hash:base64:5]!autoprefixer?browsers=last 2 version!less?outputStyle=expanded&sourceMap' },
       { test: /\.scss$/, loader: 'style!css?modules&importLoaders=2&sourceMap&localIdentName=[local]___[hash:base64:5]!autoprefixer?browsers=last 2 version!sass?outputStyle=expanded&sourceMap' },
-      { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
-      { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
-      { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/octet-stream" },
-      { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: "file" },
-      { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=image/svg+xml" },
+      { test: /.(woff(2)?)(\?[a-z0-9=\.]+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
+      { test: /.(ttf)(\?[a-z0-9=\.]+)?$/, loader: "url?limit=10000&mimetype=application/octet-stream" },
+      { test: /.(eot)(\?[a-z0-9=\.]+)?$/, loader: "file" },
+      { test: /.(svg)(\?[a-z0-9=\.]+)?$/, loader: "url?limit=10000&mimetype=image/svg+xml" },
       { test: webpackIsomorphicToolsPlugin.regular_expression('images'), loader: 'url-loader?limit=10240' }
     ]
   },

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -36,11 +36,10 @@ module.exports = {
       { test: /\.json$/, loader: 'json-loader' },
       { test: /\.less$/, loader: ExtractTextPlugin.extract('style', 'css?modules&importLoaders=2&sourceMap!autoprefixer?browsers=last 2 version!less?outputStyle=expanded&sourceMap=true&sourceMapContents=true') },
       { test: /\.scss$/, loader: ExtractTextPlugin.extract('style', 'css?modules&importLoaders=2&sourceMap!autoprefixer?browsers=last 2 version!sass?outputStyle=expanded&sourceMap=true&sourceMapContents=true') },
-      { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
-      { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
-      { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/octet-stream" },
-      { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: "file" },
-      { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=image/svg+xml" },
+      { test: /.(woff(2)?)(\?[a-z0-9=\.]+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
+      { test: /.(ttf)(\?[a-z0-9=\.]+)?$/, loader: "url?limit=10000&mimetype=application/octet-stream" },
+      { test: /.(eot)(\?[a-z0-9=\.]+)?$/, loader: "file" },
+      { test: /.(svg)(\?[a-z0-9=\.]+)?$/, loader: "url?limit=10000&mimetype=image/svg+xml" },
       { test: webpackIsomorphicToolsPlugin.regular_expression('images'), loader: 'url-loader?limit=10240' }
     ]
   },


### PR DESCRIPTION
Relax tests to account for larger variation in extension versioning and endings.

The previous test only allows for the forms like '?v=421.543.122' .
New tests allow for any alphanumeric endings and includes =.

This should help cover use cases where modules or 3rd party font/svg files use different versioning (like #723)