### PR TITLE
fix(devtools): Change shortcut (back) to ctrl+H for devtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ The first time it may take a little while to generate the first `webpack-assets.
 
 [Redux Devtools](https://github.com/gaearon/redux-devtools) are enabled by default in development.
 
-- <kbd>H</kbd> Toggle DevTools Dock
-- <kbd>Q</kbd> Move DevTools Dock Position
+- <kbd>CTRL</kbd>+<kbd>H</kbd> Toggle DevTools Dock
+- <kbd>CTRL</kbd>+<kbd>Q</kbd> Move DevTools Dock Position
 - see [redux-devtools-dock-monitor](https://github.com/gaearon/redux-devtools-dock-monitor) for more detailed information.
 
 If you have the 

--- a/src/containers/DevTools/DevTools.js
+++ b/src/containers/DevTools/DevTools.js
@@ -4,8 +4,8 @@ import LogMonitor from 'redux-devtools-log-monitor';
 import DockMonitor from 'redux-devtools-dock-monitor';
 
 export default createDevTools(
-  <DockMonitor toggleVisibilityKey="H"
-               changePositionKey="Q">
+  <DockMonitor toggleVisibilityKey="ctrl-H"
+               changePositionKey="ctrl-Q">
     <LogMonitor />
   </DockMonitor>
 );


### PR DESCRIPTION
Could someone review this before I merge?