### PR TITLE
fix(test) avoid arrow functions per mocha recommendations

### DIFF
--- a/api/__tests__/api-test.js
+++ b/api/__tests__/api-test.js
@@ -1,15 +1,16 @@
+/* eslint func-names:0 */
 import {expect} from 'chai';
 import {mapUrl} from '../utils/url';
 
-describe('mapUrl', () => {
-  it('extracts nothing if both params are undefined', () => {
+describe('mapUrl', function() {
+  it('extracts nothing if both params are undefined', function() {
     expect(mapUrl(undefined, undefined)).to.deep.equal({
       action: null,
       params: []
     });
   });
 
-  it('extracts nothing if the url is empty', () => {
+  it('extracts nothing if the url is empty', function() {
     const url = '';
     const splittedUrlPath = url.split('?')[0].split('/').slice(1);
     const availableActions = {a: 1, widget: {c: 1, load: () => 'baz'}};
@@ -20,7 +21,7 @@ describe('mapUrl', () => {
     });
   });
 
-  it('extracts nothing if nothing was found', () => {
+  it('extracts nothing if nothing was found', function() {
     const url = '/widget/load/?foo=bar';
     const splittedUrlPath = url.split('?')[0].split('/').slice(1);
     const availableActions = {a: 1, info: {c: 1, load: () => 'baz'}};
@@ -31,7 +32,7 @@ describe('mapUrl', () => {
     });
   });
 
-  it('extracts the available actions and the params from an relative url string with GET params', () => {
+  it('extracts the available actions and the params from an relative url string with GET params', function() {
     const url = '/widget/load/param1/xzy?foo=bar';
     const splittedUrlPath = url.split('?')[0].split('/').slice(1);
     const availableActions = {a: 1, widget: {c: 1, load: () => 'baz'}};
@@ -42,7 +43,7 @@ describe('mapUrl', () => {
     });
   });
 
-  it('extracts the available actions from an url string without GET params', () => {
+  it('extracts the available actions from an url string without GET params', function() {
     const url = '/widget/load/?foo=bar';
     const splittedUrlPath = url.split('?')[0].split('/').slice(1);
     const availableActions = {a: 1, widget: {c: 1, load: () => 'baz'}};
@@ -53,7 +54,7 @@ describe('mapUrl', () => {
     });
   });
 
-  it('does not find the avaialble action if deeper nesting is required', () => {
+  it('does not find the avaialble action if deeper nesting is required', function() {
     const url = '/widget';
     const splittedUrlPath = url.split('?')[0].split('/').slice(1);
     const availableActions = {a: 1, widget: {c: 1, load: () => 'baz'}};

--- a/api/actions/__tests__/loadInfo-test.js
+++ b/api/actions/__tests__/loadInfo-test.js
@@ -1,9 +1,10 @@
+/* eslint func-names:0 */
 import {expect} from 'chai';
 import loadInfo from '../loadInfo';
 import timekeeper from 'timekeeper';
 
-describe('loadInfo', () => {
-  it('loads the current date', () => {
+describe('loadInfo', function() {
+  it('loads the current date', function() {
     const now = Date.now();
     timekeeper.freeze(now);
 

--- a/api/actions/__tests__/widget-load-test.js
+++ b/api/actions/__tests__/widget-load-test.js
@@ -1,26 +1,27 @@
+/* eslint func-names:0 */
 import {expect} from 'chai';
 import load from '../widget/load';
 import sinon from 'sinon';
 
-describe('widget load', () => {
-  afterEach(()=> {
+describe('widget load', function() {
+  afterEach(function() {
     if ('restore' in Math.random) {
       Math.random.restore(); // reset the Math.random fixture
     }
   });
 
-  describe('successful', () => {
-    beforeEach(()=> {
+  describe('successful', function() {
+    beforeEach(function() {
       sinon.stub(Math, 'random').returns(0.4);
     });
 
-    it('uses the widgets from the session', () => {
+    it('uses the widgets from the session', function() {
       return load({session: {widgets: ['a', 'b', 'c']}}).then(widgets => {
         expect(widgets.length).to.equal(3);
       });
     });
 
-    it('initializes the widgets ', () => {
+    it('initializes the widgets ', function() {
       return load({session: {}}).then(widgets => {
         expect(widgets.length).to.equal(4);
         expect(widgets[0].color).to.equal('Red');
@@ -28,12 +29,12 @@ describe('widget load', () => {
     });
   });
 
-  describe('unsuccessful', () => {
-    beforeEach(()=> {
+  describe('unsuccessful', function() {
+    beforeEach(function() {
       sinon.stub(Math, 'random').returns(0.2);
     });
 
-    it('rejects the call', () => {
+    it('rejects the call', function() {
       return load({session: {}}).
       then(
         ()=> {

--- a/api/actions/__tests__/widget-update-test.js
+++ b/api/actions/__tests__/widget-update-test.js
@@ -1,20 +1,21 @@
+/* eslint func-names:0 */
 import {expect} from 'chai';
 import update from '../widget/update';
 import sinon from 'sinon';
 
-describe('widget update', () => {
-  afterEach(()=> {
+describe('widget update', function() {
+  afterEach(function() {
     if ('restore' in Math.random) {
       Math.random.restore(); // reset the Math.random fixture
     }
   });
 
-  describe('randomly successful', () => {
-    beforeEach(()=> {
+  describe('randomly successful', function() {
+    beforeEach(function() {
       sinon.stub(Math, 'random').returns(0.3);
     });
 
-    it('does not accept green widgets', () => {
+    it('does not accept green widgets', function() {
       return update({session: {}, body: {color: 'Green'}}).
       then(
         ()=> {
@@ -24,7 +25,7 @@ describe('widget update', () => {
         });
     });
 
-    it('updates a widget', () => {
+    it('updates a widget', function() {
       const widget = {id: 2, color: 'Blue'};
       return update({session: {}, body: widget}).
       then(
@@ -34,12 +35,12 @@ describe('widget update', () => {
     });
   });
 
-  describe('randomly unsuccessful', () => {
-    beforeEach(()=> {
+  describe('randomly unsuccessful', function() {
+    beforeEach(function() {
       sinon.stub(Math, 'random').returns(0.1);
     });
 
-    it('rejects the call in 20% of the time', () => {
+    it('rejects the call in 20% of the time', function() {
       return update().
       then(
         ()=> {

--- a/src/helpers/__tests__/connectData-test.js
+++ b/src/helpers/__tests__/connectData-test.js
@@ -1,15 +1,16 @@
+/* eslint func-names:0 */
 import { expect } from 'chai';
 import React from 'react';
 import { div } from 'react-dom';
 import connectData from '../connectData';
 
-describe('connectData', () => {
+describe('connectData', function() {
   let fetchData;
   let fetchDataDeferred;
   let WrappedComponent;
   let DataComponent;
 
-  beforeEach(() => {
+  beforeEach(function() {
     fetchData = 'fetchDataFunction';
     fetchDataDeferred = 'fetchDataDeferredFunction';
 
@@ -19,11 +20,11 @@ describe('connectData', () => {
     DataComponent = connectData(fetchData, fetchDataDeferred)(WrappedComponent);
   });
 
-  it('should set fetchData as a static property of the final component', () => {
+  it('should set fetchData as a static property of the final component', function() {
     expect(DataComponent.fetchData).to.equal(fetchData);
   });
 
-  it('should set fetchDataDeferred as a static property of the final component', () => {
+  it('should set fetchDataDeferred as a static property of the final component', function() {
     expect(DataComponent.fetchDataDeferred).to.equal(fetchDataDeferred);
   });
 });

--- a/src/helpers/__tests__/getDataDependencies-test.js
+++ b/src/helpers/__tests__/getDataDependencies-test.js
@@ -1,9 +1,10 @@
+/* eslint func-names:0 */
 import { expect } from 'chai';
 import React from 'react';
 import { div } from 'react-dom';
 import getDataDependencies from '../getDataDependencies';
 
-describe('getDataDependencies', () => {
+describe('getDataDependencies', function() {
   let getState;
   let dispatch;
   let location;
@@ -13,7 +14,7 @@ describe('getDataDependencies', () => {
   let CompWithFetchDataDeferred;
   const NullComponent = null;
 
-  beforeEach(() => {
+  beforeEach(function() {
     getState = 'getState';
     dispatch = 'dispatch';
     location = 'location';
@@ -36,7 +37,7 @@ describe('getDataDependencies', () => {
     };
   });
 
-  it('should get fetchDatas', () => {
+  it('should get fetchDatas', function() {
     const deps = getDataDependencies([
       NullComponent,
       CompWithFetchData,
@@ -49,7 +50,7 @@ describe('getDataDependencies', () => {
     ]);
   });
 
-  it('should get fetchDataDeferreds', () => {
+  it('should get fetchDataDeferreds', function() {
     const deps = getDataDependencies([
       NullComponent,
       CompWithFetchData,

--- a/src/helpers/__tests__/getStatusFromRoutes-test.js
+++ b/src/helpers/__tests__/getStatusFromRoutes-test.js
@@ -1,8 +1,9 @@
+/* eslint func-names:0 */
 import { expect } from 'chai';
 import getStatusFromRoutes from '../getStatusFromRoutes';
 
-describe('getStatusFromRoutes', () => {
-  it('should return null when no routes have status code', () => {
+describe('getStatusFromRoutes', function() {
+  it('should return null when no routes have status code', function() {
     const status = getStatusFromRoutes([
         {}, {}
     ]);
@@ -10,7 +11,7 @@ describe('getStatusFromRoutes', () => {
     expect(status).to.equal(null);
   });
 
-  it('should return the only status code', () => {
+  it('should return the only status code', function() {
     const status = getStatusFromRoutes([
         {status: 404}
     ]);
@@ -18,7 +19,7 @@ describe('getStatusFromRoutes', () => {
     expect(status).to.equal(404);
   });
 
-  it('should return the only status code when other routes have none', () => {
+  it('should return the only status code when other routes have none', function() {
     const status = getStatusFromRoutes([
         {status: 404}, {}, {}
     ]);
@@ -26,7 +27,7 @@ describe('getStatusFromRoutes', () => {
     expect(status).to.equal(404);
   });
 
-  it('should return the last status code when later routes have none', () => {
+  it('should return the last status code when later routes have none', function() {
     const status = getStatusFromRoutes([
         {status: 200}, {status: 404}, {}
     ]);
@@ -34,7 +35,7 @@ describe('getStatusFromRoutes', () => {
     expect(status).to.equal(404);
   });
 
-  it('should return the last status code when previous routes have one', () => {
+  it('should return the last status code when previous routes have one', function() {
     const status = getStatusFromRoutes([
         {status: 200}, {}, {status: 404}
     ]);
@@ -42,7 +43,7 @@ describe('getStatusFromRoutes', () => {
     expect(status).to.equal(404);
   });
 
-  it('should return the last status code', () => {
+  it('should return the last status code', function() {
     const status = getStatusFromRoutes([
         {}, {}, {status: 404}
     ]);

--- a/src/helpers/__tests__/makeRouteHooksSafe-test.js
+++ b/src/helpers/__tests__/makeRouteHooksSafe-test.js
@@ -1,11 +1,12 @@
+/* eslint func-names:0 */
 import { expect } from 'chai';
 import React from 'react';
 import { IndexRoute, Route } from 'react-router';
 import makeRouteHooksSafe from '../makeRouteHooksSafe';
 
 
-describe('makeRouteHooksSafe', () => {
-  it('should work with JSX routes', () => {
+describe('makeRouteHooksSafe', function() {
+  it('should work with JSX routes', function() {
     const onEnter = () => {
       throw new Error('Shouldn\'t call onEnter');
     };
@@ -30,7 +31,7 @@ describe('makeRouteHooksSafe', () => {
     expect(routes[0].childRoutes[1].childRoutes[1].onEnter).to.not.throw(Error);
   });
 
-  it('should work with JS routes', () => {
+  it('should work with JS routes', function() {
     const onEnter = () => {
       throw new Error('Shouldn\'t call onEnter');
     };
@@ -62,7 +63,7 @@ describe('makeRouteHooksSafe', () => {
     expect(routes[0].childRoutes[1].onEnter).to.not.throw(Error);
   });
 
-  it('should call onEnter if store is initialised', (done) => {
+  it('should call onEnter if store is initialised', function(done) {
     const store = {
       getState: () => {}
     };
@@ -80,7 +81,7 @@ describe('makeRouteHooksSafe', () => {
     routes[0].onEnter();
   });
 
-  it('should call callback', (done) => {
+  it('should call callback', function(done) {
     const getRoutes = makeRouteHooksSafe(() => {
       return {
         onEnter: (nextState, replaceState, cb) => {} // eslint-disable-line no-unused-vars
@@ -92,7 +93,7 @@ describe('makeRouteHooksSafe', () => {
     routes[0].onEnter(null, null, done);
   });
 
-  it('should not call callback', () => {
+  it('should not call callback', function() {
     const callback = () => {
       throw new Error('Should not be called');
     };


### PR DESCRIPTION
Using arrow functions blocks access to Mocha-specific methods, like this.timeout() and this.slow(). The maintainers recommend using good old function expressions.
https://mochajs.org/#arrow-functions

I've disabled the func-names rule at the top of test files. I'm not sure if this is the best solution. Naming functions within tests doesn't provide any benefit (the test outputs the name of the test!) but it seems a bit boilerplate / brute-force.
