### PR TITLE
style(lint): add semi-colons for class properties

### DIFF
--- a/src/components/CounterButton/CounterButton.js
+++ b/src/components/CounterButton/CounterButton.js
@@ -11,11 +11,11 @@ export default class CounterButton extends Component {
     count: PropTypes.number,
     increment: PropTypes.func.isRequired,
     className: PropTypes.string
-  }
+  };
 
   props = {
     className: ''
-  }
+  };
 
   render() {
     const {count, increment} = this.props; // eslint-disable-line no-shadow

--- a/src/components/InfoBar/InfoBar.js
+++ b/src/components/InfoBar/InfoBar.js
@@ -10,7 +10,7 @@ export default class InfoBar extends Component {
   static propTypes = {
     info: PropTypes.object,
     load: PropTypes.func.isRequired
-  }
+  };
 
   render() {
     const {info, load} = this.props; // eslint-disable-line no-shadow

--- a/src/components/MiniInfoBar/MiniInfoBar.js
+++ b/src/components/MiniInfoBar/MiniInfoBar.js
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 export default class MiniInfoBar extends Component {
   static propTypes = {
     time: PropTypes.number
-  }
+  };
 
   render() {
     const {time} = this.props;

--- a/src/components/SurveyForm/SurveyForm.js
+++ b/src/components/SurveyForm/SurveyForm.js
@@ -43,7 +43,7 @@ class SurveyForm extends Component {
     invalid: PropTypes.bool.isRequired,
     pristine: PropTypes.bool.isRequired,
     valid: PropTypes.bool.isRequired
-  }
+  };
 
   render() {
     const {

--- a/src/containers/About/About.js
+++ b/src/containers/About/About.js
@@ -6,7 +6,7 @@ export default class About extends Component {
 
   state = {
     showKitten: false
-  }
+  };
 
   handleToggleKitten = () => this.setState({showKitten: !this.state.showKitten});
 

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -53,7 +53,7 @@ export default class App extends Component {
   handleLogout = (event) => {
     event.preventDefault();
     this.props.logout();
-  }
+  };
 
   render() {
     const {user} = this.props;

--- a/src/containers/Chat/Chat.js
+++ b/src/containers/Chat/Chat.js
@@ -34,7 +34,7 @@ export default class Chat extends Component {
     const messages = this.state.messages;
     messages.push(data);
     this.setState({messages});
-  }
+  };
 
   handleSubmit = (event) => {
     event.preventDefault();
@@ -47,7 +47,7 @@ export default class Chat extends Component {
       from: this.props.user.name,
       text: msg
     });
-  }
+  };
 
   render() {
     const style = require('./Chat.scss');

--- a/src/containers/Login/Login.js
+++ b/src/containers/Login/Login.js
@@ -11,14 +11,14 @@ export default class Login extends Component {
     user: PropTypes.object,
     login: PropTypes.func,
     logout: PropTypes.func
-  }
+  };
 
   handleSubmit = (event) => {
     event.preventDefault();
     const input = this.refs.username;
     this.props.login(input.value);
     input.value = '';
-  }
+  };
 
   render() {
     const {user, logout} = this.props;

--- a/src/containers/LoginSuccess/LoginSuccess.js
+++ b/src/containers/LoginSuccess/LoginSuccess.js
@@ -10,7 +10,7 @@ class LoginSuccess extends Component {
   static propTypes = {
     user: PropTypes.object,
     logout: PropTypes.func
-  }
+  };
 
   render() {
     const {user, logout} = this.props;

--- a/src/containers/Survey/Survey.js
+++ b/src/containers/Survey/Survey.js
@@ -10,12 +10,12 @@ import {SurveyForm} from 'components';
 export default class Survey extends Component {
   static propTypes = {
     initialize: PropTypes.func.isRequired
-  }
+  };
 
   handleSubmit = (data) => {
     window.alert('Data submitted! ' + JSON.stringify(data));
     this.props.initialize('survey', {});
-  }
+  };
 
   handleInitialize = () => {
     this.props.initialize('survey', {
@@ -25,7 +25,7 @@ export default class Survey extends Component {
       currentlyEmployed: true,
       sex: 'male'
     });
-  }
+  };
 
   render() {
     return (

--- a/src/containers/Widgets/Widgets.js
+++ b/src/containers/Widgets/Widgets.js
@@ -31,7 +31,7 @@ export default class Widgets extends Component {
     editing: PropTypes.object.isRequired,
     load: PropTypes.func.isRequired,
     editStart: PropTypes.func.isRequired
-  }
+  };
 
   render() {
     const handleEdit = (widget) => {


### PR DESCRIPTION
Current versions for linter / babel demand semi-colons for class-properties.
This PR adds in those semi-colons so that the lint will pass for a fresh clone of this repo.