### PR TITLE
`match` validator function is a reserved word in js

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "compression": "^1.6.0",
     "express": "^4.13.3",
     "express-session": "^1.12.1",
-    "history": "^1.13.0",
+    "history": "^1.13.1",
     "file-loader": "^0.8.5",
     "hoist-non-react-statics": "^1.0.3",
     "http-proxy": "^1.12.0",
@@ -118,6 +118,7 @@
     "socket.io-client": "^1.3.7",
     "superagent": "^1.4.0",
     "url-loader": "^0.5.7",
+    "warning": "^2.1.0",
     "webpack-isomorphic-tools": "^2.2.18"
   },
   "devDependencies": {

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -44,7 +44,7 @@ export function oneOf(enumeration) {
   };
 }
 
-export function match(field) {
+export function matches(field) {
   return (value, data) => {
     if (data) {
       if (value !== data[field]) {


### PR DESCRIPTION
the `match` javascript function is a reserved word. We are unable to use this within the validation. Lets change it to `matches()`.

not sure why this has slipped passed for so long?
