### PR TITLE
Prevent double render in dev mode by branching

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -43,13 +43,6 @@ const component = (
   <ReduxRouter routes={getRoutes(store)} />
 );
 
-ReactDOM.render(
-  <Provider store={store} key="provider">
-    {component}
-  </Provider>,
-  dest
-);
-
 if (process.env.NODE_ENV !== 'production') {
   window.React = React; // enable debugger
 
@@ -66,6 +59,13 @@ if (__DEVTOOLS__ && !window.devToolsExtension) {
         {component}
         <DevTools />
       </div>
+    </Provider>,
+    dest
+  );
+} else {
+  ReactDOM.render(
+    <Provider store={store} key="provider">
+      {component}
     </Provider>,
     dest
   );


### PR DESCRIPTION
In dev the root App component (and its children) always mount twice
because of the structure of the code. I'm not sure if this is desired
but it's a confusing behavior to see double renders in dev.