### PR TITLE
feat(ci): add support for circle-ci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,17 @@
+machine:
+  node:
+    version: 4.0
+  environment:
+    CONTINUOUS_INTEGRATION: true
+
+dependencies:
+  cache_directories:
+    - node_modules
+  override:
+    - npm prune && npm install
+
+test:
+  override:
+    - npm run lint
+    - npm test
+    - npm run test-node

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,7 +5,7 @@ module.exports = function (config) {
 
     browsers: ['PhantomJS'],
 
-    singleRun: !!process.env.CONTINUOUS_INTEGRATION,
+    singleRun: !!process.env.CI,
 
     frameworks: [ 'mocha' ],
 


### PR DESCRIPTION
working towards support for circle ci #908 

changes `CONTINUOUS_INTEGRATION` environment variable to `CI` for support in both Circle CI and Travis CI

example circle ci build for this pr: https://circleci.com/gh/zaccolley/react-redux-universal-hot-example
you can see an example travis here: https://travis-ci.org/zaccolley/react-redux-universal-hot-example