### PR TITLE
Update to node 5.x.x addresses Babel 6 issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "0.12"
   - "4.0"
   - "4"
+  - "5"
   - "stable"
 
 sudo: false

--- a/package.json
+++ b/package.json
@@ -187,6 +187,6 @@
     "webpack-hot-middleware": "^2.5.0"
   },
   "engines": {
-    "node": "4.1.1"
+    "node": "5.6.0"
   }
 }


### PR DESCRIPTION
The pull request to update Babel `6.x.x` raises the old `ReferenceError: _ApiClient is not defined` error on fresh installation, with node `4.2.4`.

All tests are green and everything seems fine with node `5.6.0`. Think its time to upgrade... Babel 6 plays nicer with 5.x.x anyway.

see PR: https://github.com/erikras/react-redux-universal-hot-example/pull/935