### PR TITLE
Replace deprecated method in react-router v2.0.0

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -14,12 +14,12 @@ import {
   } from 'containers';
 
 export default (store) => {
-  const requireLogin = (nextState, replaceState, cb) => {
+  const requireLogin = (nextState, replace, cb) => {
     function checkAuth() {
       const { auth: { user }} = store.getState();
       if (!user) {
         // oops, not logged in, so can't be here!
-        replaceState(null, '/');
+        replace('/');
       }
       cb();
     }


### PR DESCRIPTION
Run this example while not logged in, redirect to routes with `onEnter={requireLogin}` hook will trigger following warning in the termninal.

Warning: [react-router] `replaceState(state, pathname, query) is deprecated; use `replace(location)` with a location descriptor instead. http://tiny.cc/router-isActivedeprecated

This page contains the detailed upgrade guide for `react-router` v2.0.0

https://github.com/reactjs/react-router/blob/master/upgrade-guides/v2.0.0.md#link-to-onenter-and-isactive-use-location-descriptors