### PR TITLE
chore(scripts): `npm start` for development instead of production

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   ],
   "main": "bin/server.js",
   "scripts": {
-    "start": "concurrent --kill-others \"npm run start-prod\" \"npm run start-prod-api\"",
+    "start": "npm run dev",
+    "prod": "concurrent --kill-others \"npm run start-prod\" \"npm run start-prod-api\"",
     "start-prod": "better-npm-run start-prod",
     "start-prod-api": "better-npm-run start-prod-api",
     "build": "better-npm-run build",


### PR DESCRIPTION
```npm start``` is the first guess of any developer that uses node.js and npm

So, let's guide our begginers to Fall in the Pit of Success™ as always as possible, in this case, using ```npm start``` as the default command for development.

It's better to do the heavy lifting on other environments (CI's and production deploy), like running custom npm run commands (```npm run xyz```), and make human life easier on repetitive tasks.