### PR TITLE
prevent router rerender when devtools enabled (also fix react router hooks double calling at client side)

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -58,14 +58,13 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 if (__DEVTOOLS__ && !window.devToolsExtension) {
+  const devToolsDest = document.createElement('div');
+  window.document.body.insertBefore(devToolsDest, null);
   const DevTools = require('./containers/DevTools/DevTools');
   ReactDOM.render(
     <Provider store={store} key="provider">
-      <div>
-        {component}
-        <DevTools />
-      </div>
+      <DevTools />
     </Provider>,
-    dest
+    devToolsDest
   );
 }


### PR DESCRIPTION
this PR also fix bug with double calling react router hooks, just add onEnter hook to root Route with console.log and you will see thats doubled on first render at client side with devtools enabled, therefore all hooks, especially which used async actions will be called twice and in dev enviroment you will have duplicated requests to api

client.js

``` javascript
const oopsHookCalledTwice = () => {
    console.log('test');
  };

<Route onEnter={oopsHookCalledTwice} path="/" component={App}>
...
</Route>
```
