### PR TITLE
fix(webpack): parse port to int when calculating webpack-dev-server port

### DIFF
--- a/webpack/webpack-dev-server.js
+++ b/webpack/webpack-dev-server.js
@@ -6,7 +6,7 @@ var webpackConfig = require('./dev.config');
 var compiler = webpack(webpackConfig);
 
 var host = config.host || 'localhost';
-var port = (config.port + 1) || 3001;
+var port = parseInt(config.port) + 1 || 3001;
 var serverOptions = {
   contentBase: 'http://' + host + ':' + port,
   quiet: true,


### PR DESCRIPTION
Applying recently merged commit 3ec5ecb4a949c76d06da91d8a7688e8feefb3f48 revealed this bug. When `webpack-dev-server` has a environment variable, say 3000, it will serve on port 30001 rather than 3001