### PR TITLE
fix(webpack): convert webpack-dev-server port to number

### DIFF
--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -6,7 +6,7 @@ var path = require('path');
 var webpack = require('webpack');
 var assetsPath = path.resolve(__dirname, '../static/dist');
 var host = (process.env.HOST || 'localhost');
-var port = parseInt(process.env.PORT) + 1 || 3001;
+var port = (+process.env.PORT + 1) || 3001;
 
 // https://github.com/halt-hammerzeit/webpack-isomorphic-tools
 var WebpackIsomorphicToolsPlugin = require('webpack-isomorphic-tools/plugin');


### PR DESCRIPTION
Applying recently merged commit 3ec5ecb revealed this bug. When webpack-dev-server has a environment variable, say 3000, it will serve on port 30001 rather than 3001.

https://github.com/erikras/react-redux-universal-hot-example/pull/979#discussion_r54746146 gave this solution to replace the original one #979.