### PR TITLE
fix(webpack): convert web server port to number in webpack-dev-server config

### DIFF
--- a/webpack/webpack-dev-server.js
+++ b/webpack/webpack-dev-server.js
@@ -6,7 +6,7 @@ var webpackConfig = require('./dev.config');
 var compiler = webpack(webpackConfig);
 
 var host = config.host || 'localhost';
-var port = (config.port + 1) || 3001;
+var port = (+config.port + 1) || 3001;
 var serverOptions = {
   contentBase: 'http://' + host + ':' + port,
   quiet: true,


### PR DESCRIPTION
Hey I'm really sorry for making change on a non relevant parseInt in #980(didn't do harm though). This pull request is what actually solves the bug that causes webpack-dev-server to serve on port 30001 rather than 3001 when passing in an environment variable.