### PR TITLE
fix(api): error message had wrong env var listed

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -87,5 +87,5 @@ if (config.apiPort) {
   });
   io.listen(runnable);
 } else {
-  console.error('==>     ERROR: No PORT environment variable has been specified');
+  console.error('==>     ERROR: No APIPORT environment variable has been specified');
 }


### PR DESCRIPTION
Changed "Error .. No PORT env var specified" to APIPORT, as that's what is missing