### PR TITLE
fix: double-render can cause router issues in development

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -42,21 +42,6 @@ const component = (
   </Router>
 );
 
-ReactDOM.render(
-  <Provider store={store} key="provider">
-    {component}
-  </Provider>,
-  dest
-);
-
-if (process.env.NODE_ENV !== 'production') {
-  window.React = React; // enable debugger
-
-  if (!dest || !dest.firstChild || !dest.firstChild.attributes || !dest.firstChild.attributes['data-react-checksum']) {
-    console.error('Server-side React render was discarded. Make sure that your initial render does not contain any client-side code.');
-  }
-}
-
 if (__DEVTOOLS__ && !window.devToolsExtension) {
   const DevTools = require('./containers/DevTools/DevTools');
   ReactDOM.render(
@@ -68,4 +53,19 @@ if (__DEVTOOLS__ && !window.devToolsExtension) {
     </Provider>,
     dest
   );
+} else {
+  ReactDOM.render(
+    <Provider store={store} key="provider">
+      {component}
+    </Provider>,
+    dest
+  );
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  window.React = React; // enable debugger
+
+  if (!dest || !dest.firstChild || !dest.firstChild.attributes || !dest.firstChild.attributes['data-react-checksum']) {
+    console.error('Server-side React render was discarded. Make sure that your initial render does not contain any client-side code.');
+  }
 }


### PR DESCRIPTION
I used this as a boilerplate for a project at work. Re-rendering the app with DevTools unfortunately cause a somewhat hard to diagnose bug with react-router's [confirm navigation API](https://github.com/reactjs/react-router/blob/master/docs/guides/ConfirmingNavigation.md). Since the component tree is re-mounted but the router is not re-instantiated, it was causing a warning about setting multiple leave hooks.

While I don't think this project uses that API, it is probably better to only render once in the first place, unless I'm missing something.