### PR TITLE
fix: prevent component from mounting twice in dev

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -42,9 +42,11 @@ const component = (
   </Router>
 );
 
+// extra <div> required so component doesn't
+// re-mount when devtools are loaded below
 ReactDOM.render(
   <Provider store={store} key="provider">
-    {component}
+    <div>{component}</div>
   </Provider>,
   dest
 );

--- a/src/server.js
+++ b/src/server.js
@@ -89,9 +89,11 @@ app.use((req, res) => {
       hydrateOnClient();
     } else if (renderProps) {
       loadOnServer({...renderProps, store, helpers: {client}}).then(() => {
+        // extra <div> required so component doesn't
+        // re-mount when devtools are loaded in client.js
         const component = (
           <Provider store={store} key="provider">
-            <ReduxAsyncConnect {...renderProps} />
+            <div><ReduxAsyncConnect {...renderProps} /></div>
           </Provider>
         );
 


### PR DESCRIPTION
I used this as a boilerplate for a project at work. Re-rendering the app with DevTools unfortunately cause a somewhat hard to diagnose bug with react-router's [confirm navigation API](https://github.com/reactjs/react-router/blob/master/docs/guides/ConfirmingNavigation.md). Since the component tree is re-mounted but the router is not re-instantiated, it was causing a warning about setting multiple leave hooks. Though this library doesn't use that API, I think it's worth preventing this error in the first place.

While not particularly pretty, adding an extra `<div />` when rendering prevents the component from unmounting and re-mounting when `<DevTools /> is added.