### PR TITLE
fix(router) match routes before client side rendering

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -8,7 +8,7 @@ import createStore from './redux/create';
 import ApiClient from './helpers/ApiClient';
 import io from 'socket.io-client';
 import {Provider} from 'react-redux';
-import { Router, browserHistory } from 'react-router';
+import { Router, browserHistory, match } from 'react-router';
 import { ReduxAsyncConnect } from 'redux-async-connect';
 import useScroll from 'scroll-behavior/lib/useStandardScroll';
 
@@ -34,38 +34,40 @@ function initSocket() {
 
 global.socket = initSocket();
 
-const component = (
-  <Router render={(props) =>
-        <ReduxAsyncConnect {...props} helpers={{client}} filter={item => !item.deferred} />
-      } history={history}>
-    {getRoutes(store)}
-  </Router>
-);
+const routes = getRoutes(store);
 
-ReactDOM.render(
-  <Provider store={store} key="provider">
-    {component}
-  </Provider>,
-  dest
-);
+match({ history, routes }, (error, redirectLocation, renderProps) => {
+  const component = (
+    <Router {...renderProps} render={(props) =>
+          <ReduxAsyncConnect {...props} helpers={{client}} filter={item => !item.deferred} />
+        } history={history} routes={routes} />
+  );
 
-if (process.env.NODE_ENV !== 'production') {
-  window.React = React; // enable debugger
-
-  if (!dest || !dest.firstChild || !dest.firstChild.attributes || !dest.firstChild.attributes['data-react-checksum']) {
-    console.error('Server-side React render was discarded. Make sure that your initial render does not contain any client-side code.');
-  }
-}
-
-if (__DEVTOOLS__ && !window.devToolsExtension) {
-  const DevTools = require('./containers/DevTools/DevTools');
   ReactDOM.render(
     <Provider store={store} key="provider">
-      <div>
-        {component}
-        <DevTools />
-      </div>
+      {component}
     </Provider>,
     dest
   );
-}
+
+  if (process.env.NODE_ENV !== 'production') {
+    window.React = React; // enable debugger
+
+    if (!dest || !dest.firstChild || !dest.firstChild.attributes || !dest.firstChild.attributes['data-react-checksum']) {
+      console.error('Server-side React render was discarded. Make sure that your initial render does not contain any client-side code.');
+    }
+  }
+
+  if (__DEVTOOLS__ && !window.devToolsExtension) {
+    const DevTools = require('./containers/DevTools/DevTools');
+    ReactDOM.render(
+      <Provider store={store} key="provider">
+        <div>
+          {component}
+          <DevTools />
+        </div>
+      </Provider>,
+      dest
+    );
+  }
+});


### PR DESCRIPTION
According to react-router documentation match function should be used for client code if server side rendering is used with async routes.

Source: https://github.com/reactjs/react-router/blob/master/docs/guides/ServerRendering.md

Since loadAuth() is called from onEnter hooks this code applies to this boilerplate.

In some use cases initial client render does not match the html rendered from server and the client discards the server rendered html. Then the second client render is made and the result is actually the same as the one server rendered.

In this case react markup mismatch warning and the following error are produced:
`Server-side React render was discarded. Make sure that your initial render does not contain any client-side code.`

By using react-router match function, this mismatch is prevented.

Example use case: Handling 4xx errors on loadAuth result.
