### PR TITLE
fixes #830 API debug from IDEs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -21,5 +21,7 @@
         }]
       ]
     }
-  }
+  },
+
+  "retainLines": true
 }

--- a/api/api.js
+++ b/api/api.js
@@ -3,7 +3,7 @@ import session from 'express-session';
 import bodyParser from 'body-parser';
 import config from '../src/config';
 import * as actions from './actions/index';
-import {mapUrl} from 'utils/url.js';
+import {mapUrl} from './utils/url.js';
 import PrettyError from 'pretty-error';
 import http from 'http';
 import SocketIo from 'socket.io';


### PR DESCRIPTION
Fixes #830

It allows to put breakpoints correctly (retainLines) while stopping somewhere on the breakpoint.
And also fix the import that was pointing to incorrect path when you tried to debug API (it doesn't break anything, and it simply fix a debug).

Settings to be capable of debugging that in IDE are (env variables):
```
NODE_ENV=production
APIPORT
```
`NODE_ENV ` is important due to the fact that if you will see development for example, pipeling will simply destorys the possibility of debugging in IDE
APIPORT is up to you, you can set whatever you wish (API will be hosted on that port). For example 3030.
Tested with WebStorm and Visual Studio Code (below)

![image](https://cloud.githubusercontent.com/assets/9503398/14018638/104f2a1e-f1cf-11e5-8414-3e99a6381fdf.png)

![image](https://cloud.githubusercontent.com/assets/9503398/14018656/1e63e7d4-f1cf-11e5-9df5-89324c4a4118.png)

