### PR TITLE
fix(devtools): render Devtools on a separate node - prevent initial double render

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -59,13 +59,12 @@ if (process.env.NODE_ENV !== 'production') {
 
 if (__DEVTOOLS__ && !window.devToolsExtension) {
   const DevTools = require('./containers/DevTools/DevTools');
+  const devToolsDest = document.createElement('div');
+  dest.parentNode.insertBefore(devToolsDest, dest.nextSibling);
   ReactDOM.render(
     <Provider store={store} key="provider">
-      <div>
-        {component}
-        <DevTools />
-      </div>
+      <DevTools />
     </Provider>,
-    dest
+    devToolsDest
   );
 }


### PR DESCRIPTION
_Render_ (and _componentDidMount_) is currently called twice on the client when Devtools is enabled.
We can avoid this by mounting the Devtools on separate node, next to the root **div#content**.

Issue related: #429 