### PR TITLE
using redis as session store

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -10,6 +10,7 @@ import SocketIo from 'socket.io';
 
 const pretty = new PrettyError();
 const app = express();
+const RedisStore = require('connect-redis')(session);
 
 const server = new http.Server(app);
 
@@ -18,6 +19,10 @@ io.path('/ws');
 
 app.use(session({
   secret: 'react and redux rule!!!!',
+  store: new RedisStore({
+    host: '127.0.0.1',
+    port: 6379
+  }),
   resave: false,
   saveUninitialized: false,
   cookie: { maxAge: 60000 }

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "babel-runtime": "^6.3.19",
     "body-parser": "^1.14.1",
     "compression": "^1.6.0",
+    "connect-redis": "^3.0.2",
     "express": "^4.13.3",
     "express-session": "^1.12.1",
     "file-loader": "^0.8.5",


### PR DESCRIPTION
As a modern, cutting-age web framework, Redis might be better as the default caching strategy.
And by putting redis as its default cache, more users will be attracted.