### PR TITLE
docs(guide): Nitrous.io Quickstart button

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ npm run build
 npm run start
 ```
 
+## Nitrous Quickstart
+
+You can quickly create a free development environment for this project in the cloud on www.nitrous.io:
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+In the IDE, start this project via `Run > Start React Redux Example` and access your site via `Preview > 3000`.
+
 ## Demo
 
 A demonstration of this app can be seen [running on heroku](https://react-redux.herokuapp.com), which is a deployment of the [heroku branch](https://github.com/erikras/react-redux-universal-hot-example/tree/heroku).

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,13 @@
+# Setup
+
+Welcome to your React Redux Universal Hot Example project on Nitrous.
+
+## Running the development server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), start React Redux Universal Hot Example via "Run > Start React Redux Example" and wait for 30 seconds for the first time.
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 3000".

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,10 @@
+{
+  "template": "nodejs",
+  "ports": [3000, 3030],
+  "name": "React Redux Universal Hot Example",
+  "description": "A starter boilerplate for a universal webapp using express, react, redux, webpack, and react-transform",
+  "scripts": {
+    "post-create": "cd ~/code/react-redux-universal-hot-example && echo 'running npm install...' && npm install --no-progress  && echo 'npm install done'",
+    "Start React Redux Example": "cd ~/code/react-redux-universal-hot-example && npm run dev"
+  }
+}


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages.