### PR TITLE
Fixing "_ApiClient is not defined" by adding empty class method to ApiClient

### DIFF
--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -13,13 +13,7 @@ function formatUrl(path) {
   return '/api' + adjustedPath;
 }
 
-/*
- * This silly underscore is here to avoid a mysterious "ReferenceError: ApiClient is not defined" error.
- * See Issue #14. https://github.com/erikras/react-redux-universal-hot-example/issues/14
- *
- * Remove it at your own risk.
- */
-class _ApiClient {
+export default class ApiClient {
   constructor(req) {
     methods.forEach((method) =>
       this[method] = (path, { params, data } = {}) => new Promise((resolve, reject) => {
@@ -40,8 +34,15 @@ class _ApiClient {
         request.end((err, { body } = {}) => err ? reject(body || err) : resolve(body));
       }));
   }
+  /*
+   * There's a V8 bug where, when using Babel, exporting classes with only
+   * constructors sometimes fails. Until it's patched, this is a solution to
+   * "ApiClient is not defined" from issue #14.
+   * https://github.com/erikras/react-redux-universal-hot-example/issues/14
+   *
+   * Relevant Babel bug (but they claim it's V8): https://phabricator.babeljs.io/T2455
+   *
+   * Remove it at your own risk.
+   */
+  empty() {}
 }
-
-const ApiClient = _ApiClient;
-
-export default ApiClient;


### PR DESCRIPTION
Fixes issue #14 #31 #51

Babel bug https://phabricator.babeljs.io/T2455 which is fixed and
closed. I don't know which version of babel fixed it but the latest core
works fine.