### PR TITLE
addressed TODO: made SurveyForm use api endpoint for validation

### DIFF
--- a/api/actions/index.js
+++ b/api/actions/index.js
@@ -3,3 +3,4 @@ export loadAuth from './loadAuth';
 export login from './login';
 export logout from './logout';
 export * as widget from './widget/index';
+export * as survey from './survey/index';

--- a/api/actions/survey/index.js
+++ b/api/actions/survey/index.js
@@ -1,0 +1,1 @@
+export isValid from './isValid';

--- a/api/actions/survey/isValid.js
+++ b/api/actions/survey/isValid.js
@@ -1,0 +1,17 @@
+export default function survey(req) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      const errors = {};
+      let valid = true;
+      if (~['bobby@gmail.com', 'timmy@microsoft.com'].indexOf(req.body.email)) {
+        errors.email = 'Email address already used';
+        valid = false;
+      }
+      if (valid) {
+        resolve();
+      } else {
+        reject(errors);
+      }
+    }, 1000);
+  });
+}

--- a/src/components/SurveyForm/SurveyForm.js
+++ b/src/components/SurveyForm/SurveyForm.js
@@ -1,29 +1,19 @@
 import React, {Component, PropTypes} from 'react';
 import {reduxForm} from 'redux-form';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import surveyValidation from './surveyValidation';
+import * as surveyActions from 'redux/modules/survey';
 
-function asyncValidate(data) {
-  // TODO: figure out a way to move this to the server. need an instance of ApiClient
+function asyncValidate(data, dispatch, {isValidEmail}) {
   if (!data.email) {
     return Promise.resolve({});
   }
-  return new Promise((resolve, reject) => {
-    setTimeout(() => {
-      const errors = {};
-      let valid = true;
-      if (~['bobby@gmail.com', 'timmy@microsoft.com'].indexOf(data.email)) {
-        errors.email = 'Email address already used';
-        valid = false;
-      }
-      if (valid) {
-        resolve();
-      } else {
-        reject(errors);
-      }
-    }, 1000);
-  });
+  return isValidEmail(data);
 }
-
+@connect(() => ({}),
+  dispatch => bindActionCreators(surveyActions, dispatch)
+)
 @reduxForm({
   form: 'survey',
   fields: ['name', 'email', 'occupation', 'currentlyEmployed', 'sex'],
@@ -137,4 +127,3 @@ class SurveyForm extends Component {
     );
   }
 }
-

--- a/src/redux/modules/survey.js
+++ b/src/redux/modules/survey.js
@@ -1,0 +1,38 @@
+const IS_VALID = 'redux-example/survey/IS_VALID';
+const IS_VALID_SUCCESS = 'redux-example/survey/IS_VALID_SUCCESS';
+const IS_VALID_FAIL = 'redux-example/survey/IS_VALID_FAIL';
+
+const initialState = {
+  saveError: null,
+};
+
+export default function reducer(state = initialState, action = {}) {
+  switch (action.type) {
+    case IS_VALID:
+      return state; // 'saving' flag handled by redux-form
+    case IS_VALID_SUCCESS:
+      const data = [...state.data];
+      data[action.result.id - 1] = action.result;
+      return {
+        ...state,
+        data: data,
+        saveError: null,
+      };
+    case IS_VALID_FAIL:
+      return typeof action.error === 'string' ? {
+        ...state,
+        saveError: action.error
+      } : state;
+    default:
+      return state;
+  }
+}
+
+export function isValidEmail(data) {
+  return {
+    types: [IS_VALID, IS_VALID_SUCCESS, IS_VALID_FAIL],
+    promise: (client) => client.post('/survey/isValid', {
+      data
+    })
+  };
+}


### PR DESCRIPTION
Hello @erikras,

I'm trying out this repo and noticed a TODO in the survey form. I added an api endpoint for email validation. The only issue is that the survey reducer `IS_VALID_SUCCESS` and `IS_VALID_FAIL` are never called, because the `reactForm` `asyncValidate` prevents next from being called (I think that's what's going on). It's not really an issue, but leaves code that isn't called in the repo, which isn't great for an example app. The promise middleware requires `types: [initial, success, fail]`, so that could be changed and then remove the unused/unnecessary survey reducer cases.

What do you think?