### PR TITLE
fix(ApiClient): fix handling text response from server. before fix handled only json response

### DIFF
--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -31,7 +31,7 @@ export default class ApiClient {
           request.send(data);
         }
 
-        request.end((err, { body } = {}) => err ? reject(body || err) : resolve(body));
+        request.end((err, { body, text } = {}) => err ? reject(body || text || err) : resolve(body || text));
       }));
   }
   /*


### PR DESCRIPTION
Hi,

When server returns regular text, the response goes into "response.text" and not "response.body", so current ApiClient ignores it.