### PR TITLE
Allow undefined to pass integer validation

### DIFF
--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -31,7 +31,7 @@ export function maxLength(max) {
 }
 
 export function integer(value) {
-  if (!Number.isInteger(Number(value))) {
+  if (!isEmpty(value) && !Number.isInteger(Number(value))) {
     return 'Must be an integer';
   }
 }


### PR DESCRIPTION
I propose we allow `undefined` to pass `integer` validation. I have a usecase where a field is allowed to be blank but if you do enter something in the field, then it must be an integer. With this change, we only invalidate the field if a non-empty value is passed AND that value is not an integer.
