### PR TITLE
Bake-in support for webpack DLLs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,6 +32,7 @@
     "__SERVER__": true,
     "__DISABLE_SSR__": true,
     "__DEVTOOLS__": true,
+    "__DLLS__": true,
     "socket": true,
     "webpackIsomorphicTools": true
   }

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 webpack-assets.json
 webpack-stats.json
 npm-debug.log
+/.happypack

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ webpack-assets.json
 webpack-stats.json
 npm-debug.log
 /.happypack
+/webpack/dlls/manifests/*.json

--- a/bin/server.js
+++ b/bin/server.js
@@ -9,6 +9,7 @@ global.__CLIENT__ = false;
 global.__SERVER__ = true;
 global.__DISABLE_SSR__ = false;  // <----- DISABLES SERVER SIDE RENDERING FOR ERROR DEBUGGING
 global.__DEVELOPMENT__ = process.env.NODE_ENV !== 'production';
+global.__DLLS__ = process.env.WEBPACK_DLLS === '1';
 
 if (__DEVELOPMENT__) {
   if (!require('piping')({

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,8 +11,9 @@ module.exports = function (config) {
 
     files: [
       './node_modules/phantomjs-polyfill/bind-polyfill.js',
+      process.env.WEBPACK_DLLS === '1' && './static/dist/dlls/dll__vendor.js',
       'tests.webpack.js'
-    ],
+    ].filter(function(x) { return !!x; }),
 
     preprocessors: {
       'tests.webpack.js': [ 'webpack', 'sourcemap' ]
@@ -53,7 +54,8 @@ module.exports = function (config) {
           __CLIENT__: true,
           __SERVER__: false,
           __DEVELOPMENT__: true,
-          __DEVTOOLS__: false  // <-------- DISABLE redux-devtools HERE
+          __DEVTOOLS__: false,  // <-------- DISABLE redux-devtools HERE
+          __DLLS__: process.env.WEBPACK_DLLS === '1'
         })
       ]
     },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "start-prod": "better-npm-run start-prod",
     "start-prod-api": "better-npm-run start-prod-api",
     "build": "better-npm-run build",
+    "build-dlls": "./node_modules/.bin/webpack --config webpack/dlls/vendor/webpack.config.js",
     "postinstall": "npm run build",
     "lint": "eslint -c .eslintrc src api",
     "start-dev": "better-npm-run start-dev",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "extract-text-webpack-plugin": "^0.9.1",
     "font-awesome": "^4.4.0",
     "font-awesome-webpack": "0.0.4",
-    "happypack": "2.0.3",
+    "happypack": "2.1.1",
     "json-loader": "^0.5.4",
     "karma": "^0.13.10",
     "karma-cli": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "extract-text-webpack-plugin": "^0.9.1",
     "font-awesome": "^4.4.0",
     "font-awesome-webpack": "0.0.4",
+    "happypack": "2.0.3",
     "json-loader": "^0.5.4",
     "karma": "^0.13.10",
     "karma-cli": "^0.1.1",

--- a/src/helpers/Html.js
+++ b/src/helpers/Html.js
@@ -50,6 +50,13 @@ export default class Html extends Component {
         <body>
           <div id="content" dangerouslySetInnerHTML={{__html: content}}/>
           <script dangerouslySetInnerHTML={{__html: `window.__data=${serialize(store.getState())};`}} charSet="UTF-8"/>
+          {__DLLS__ && [
+            <script
+              key="dlls__vendor"
+              src="/dist/dlls/dll__vendor.js"
+              charSet="UTF-8"
+            />
+          ]}
           <script src={assets.javascript.main} charSet="UTF-8"/>
         </body>
       </html>

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -156,13 +156,13 @@ function createHappyPlugin(id) {
     id: id,
     threadPool: happyThreadPool,
 
-    // conveniently disable happy with HAPPY=0
+    // disable happypack with HAPPY=0
     enabled: process.env.HAPPY !== '0',
 
-    // disable happy caching with HAPPY_CACHE=0
+    // disable happypack caching with HAPPY_CACHE=0
     cache: process.env.HAPPY_CACHE !== '0',
 
-    // make happy more verbose with HAPPY_VERBOSE=1
+    // make happypack more verbose with HAPPY_VERBOSE=1
     verbose: process.env.HAPPY_VERBOSE === '1',
   });
 }

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -7,6 +7,8 @@ var webpack = require('webpack');
 var assetsPath = path.resolve(__dirname, '../static/dist');
 var host = (process.env.HOST || 'localhost');
 var port = (+process.env.PORT + 1) || 3001;
+var HappyPack = require('happypack');
+var happyThreadPool = HappyPack.ThreadPool({ size: 5 });
 
 // https://github.com/halt-hammerzeit/webpack-isomorphic-tools
 var WebpackIsomorphicToolsPlugin = require('webpack-isomorphic-tools/plugin');
@@ -80,12 +82,31 @@ module.exports = {
   },
   module: {
     loaders: [
-      { test: /\.jsx?$/, exclude: /node_modules/, loaders: ['babel?' + JSON.stringify(babelLoaderQuery), 'eslint-loader']},
-      { test: /\.json$/, loader: 'json-loader' },
-      { test: /\.less$/, loader: 'style!css?modules&importLoaders=2&sourceMap&localIdentName=[local]___[hash:base64:5]!autoprefixer?browsers=last 2 version!less?outputStyle=expanded&sourceMap' },
-      { test: /\.scss$/, loader: 'style!css?modules&importLoaders=2&sourceMap&localIdentName=[local]___[hash:base64:5]!autoprefixer?browsers=last 2 version!sass?outputStyle=expanded&sourceMap' },
-      { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
-      { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
+      createSourceLoader({
+        happy: { id: 'jsx' },
+        test: /\.jsx?$/,
+        loaders: ['babel?' + JSON.stringify(babelLoaderQuery), 'eslint-loader'],
+      }),
+
+      createSourceLoader({
+        happy: { id: 'json' },
+        test: /\.json$/,
+        loader: 'json-loader',
+      }),
+
+      createSourceLoader({
+        happy: { id: 'less' },
+        test: /\.less$/,
+        loader: 'style!css?modules&importLoaders=2&sourceMap&localIdentName=[local]___[hash:base64:5]!autoprefixer?browsers=last 2 version!less?outputStyle=expanded&sourceMap',
+      }),
+
+      createSourceLoader({
+        happy: { id: 'sass' },
+        test: /\.scss$/,
+        loader: 'style!css?modules&importLoaders=2&sourceMap&localIdentName=[local]___[hash:base64:5]!autoprefixer?browsers=last 2 version!sass?outputStyle=expanded&sourceMap',
+      }),
+
+      { test: /\.woff2?(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
       { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/octet-stream" },
       { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: "file" },
       { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=image/svg+xml" },
@@ -110,6 +131,38 @@ module.exports = {
       __DEVELOPMENT__: true,
       __DEVTOOLS__: true  // <-------- DISABLE redux-devtools HERE
     }),
-    webpackIsomorphicToolsPlugin.development()
+    webpackIsomorphicToolsPlugin.development(),
+
+    createHappyPlugin('jsx'),
+    createHappyPlugin('json'),
+    createHappyPlugin('less'),
+    createHappyPlugin('sass'),
   ]
 };
+
+// restrict loader to files under /src
+function createSourceLoader(spec) {
+  return Object.keys(spec).reduce(function(x, key) {
+    x[key] = spec[key];
+
+    return x;
+  }, {
+    include: [ path.resolve(__dirname, '../src') ]
+  });
+}
+
+function createHappyPlugin(id) {
+  return new HappyPack({
+    id: id,
+    threadPool: happyThreadPool,
+
+    // conveniently disable happy with HAPPY=0
+    enabled: process.env.HAPPY !== '0',
+
+    // disable happy caching with HAPPY_CACHE=0
+    cache: process.env.HAPPY_CACHE !== '0',
+
+    // make happy more verbose with HAPPY_VERBOSE=1
+    verbose: process.env.HAPPY_VERBOSE === '1',
+  });
+}

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -9,6 +9,7 @@ var host = (process.env.HOST || 'localhost');
 var port = (+process.env.PORT + 1) || 3001;
 var HappyPack = require('happypack');
 var happyThreadPool = HappyPack.ThreadPool({ size: 5 });
+var WebpackHelpers = require('./helpers');
 
 // https://github.com/halt-hammerzeit/webpack-isomorphic-tools
 var WebpackIsomorphicToolsPlugin = require('webpack-isomorphic-tools/plugin');
@@ -63,7 +64,7 @@ reactTransform[1].transforms.push({
   locals: ['module']
 });
 
-module.exports = {
+var webpackConfig = module.exports = {
   devtool: 'inline-source-map',
   context: path.resolve(__dirname, '..'),
   entry: {
@@ -129,7 +130,8 @@ module.exports = {
       __CLIENT__: true,
       __SERVER__: false,
       __DEVELOPMENT__: true,
-      __DEVTOOLS__: true  // <-------- DISABLE redux-devtools HERE
+      __DEVTOOLS__: true,  // <-------- DISABLE redux-devtools HERE
+      __DLLS__: process.env.WEBPACK_DLLS === '1'
     }),
     webpackIsomorphicToolsPlugin.development(),
 
@@ -139,6 +141,10 @@ module.exports = {
     createHappyPlugin('sass'),
   ]
 };
+
+if (process.env.WEBPACK_DLLS === '1') {
+  WebpackHelpers.installVendorDLL(webpackConfig, 'vendor');
+}
 
 // restrict loader to files under /src
 function createSourceLoader(spec) {

--- a/webpack/dlls/README.md
+++ b/webpack/dlls/README.md
@@ -1,0 +1,31 @@
+# DLLs
+
+Webpack "DLLs" can help reduce the build times a bit which is rather useful
+during development.
+
+You may opt-in to use the Vendor DLL by doing the following:
+
+- set `WEBPACK_DLLS=1` in your shell before running webpack
+- compile the DLL using `npm run build-dlls`
+
+You need to be careful to re-compile the DLL anytime a vendor module changes 
+(which is not often.)
+
+## Defining a new DLL
+
+See the `vendor` DLL under `/webpack/dlls/vendor/webpack.config.js` for 
+pointers on how to create one. Here are the guidelines:
+
+- the DLL definition goes under `/webpack/dlls/[name]/webpack.config.js`
+- the JS bundle goes under `/static/dist/dlls` with the name `dll__[name].js`
+- the compiled manifest (auto-generated) goes under `/webpack/dlls/manifests`
+  with the name `[name].json`
+- a reference to the DLL should be registered in `/webpack/dev.config.js`
+- the build script `build-dlls` defined in `package.json` must be adjusted to compile that DLL
+- the component `src/helpers/Html.js` should include the JS bundle
+- `karma.conf.js` should preload the JS bundle under `files`
+
+## Adding modules to the Vendor DLL
+
+If you add a new dependency that you want to freeze within the DLL, add it
+to `/webpack/dlls/vendor/webpack.config.js` under `entry.vendor`.

--- a/webpack/dlls/manifests/README.md
+++ b/webpack/dlls/manifests/README.md
@@ -1,0 +1,1 @@
+Files in this directory are auto-generated. DO NOT EDIT!

--- a/webpack/dlls/vendor/webpack.config.js
+++ b/webpack/dlls/vendor/webpack.config.js
@@ -1,0 +1,83 @@
+var path = require('path');
+var webpack = require('webpack');
+var root = path.resolve(__dirname, '..', '..', '..');
+
+module.exports = {
+  devtool: process.env.NODE_ENV === 'production' ? null : 'inline-source-map',
+
+  output: {
+    path: path.join(root, 'static/dist/dlls'),
+    filename: 'dll__[name].js',
+    library: 'DLL_[name]_[hash]'
+  },
+
+  entry: {
+    vendor: [
+      'babel-polyfill',
+
+      // <babel-runtime>
+      //
+      // Generate this list using the following command against the stdout of
+      // webpack running against the source bundle config (dev/prod.js):
+      //
+      //     egrep -o 'babel-runtime/\S+' | sed 's/\.js$//' | sort | uniq | wc -l
+      'babel-runtime/core-js/array/from',
+      'babel-runtime/core-js/get-iterator',
+      'babel-runtime/core-js/is-iterable',
+      'babel-runtime/core-js/json/stringify',
+      'babel-runtime/core-js/number/is-integer',
+      'babel-runtime/core-js/number/is-safe-integer',
+      'babel-runtime/core-js/object/define-property',
+      'babel-runtime/core-js/object/get-own-property-descriptor',
+      'babel-runtime/core-js/object/get-own-property-names',
+      'babel-runtime/core-js/object/get-prototype-of',
+      'babel-runtime/core-js/promise',
+      'babel-runtime/helpers/create-class',
+      'babel-runtime/helpers/createClass',
+      'babel-runtime/helpers/defineProperty',
+      'babel-runtime/helpers/get',
+      'babel-runtime/helpers/possibleConstructorReturn',
+      'babel-runtime/helpers/slicedToArray',
+      'babel-runtime/helpers/to-consumable-array',
+      'babel-runtime/helpers/toConsumableArray',
+      // </babel-runtime>
+
+      'invariant',
+      'multireducer',
+      'react',
+      'react-bootstrap',
+      'react-dom',
+      'react-helmet',
+      'react-inline-css',
+      'react-redux',
+      'react-router',
+      'react-router-bootstrap',
+      'react-router-redux',
+      'redux',
+      'redux-async-connect',
+      'redux-form',
+      'scroll-behavior',
+      'serialize-javascript',
+      'socket.io-client',
+      'superagent',
+      'warning',
+    ]
+  },
+
+  resolve: {
+    root: path.resolve(root, 'node_modules'),
+    extensions: [ '', '.js' ],
+    postfixes: [],
+  },
+
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+    }),
+
+    new webpack.DllPlugin({
+      path: path.join(root, 'webpack/dlls/manifests/[name].json'),
+      name: 'DLL_[name]_[hash]'
+    })
+  ]
+};

--- a/webpack/helpers.js
+++ b/webpack/helpers.js
@@ -1,0 +1,47 @@
+var path = require('path');
+var root = path.resolve(__dirname, '..');
+var webpack = require('webpack');
+
+exports.installVendorDLL = function(config, dllName) {
+  // DLL shizzle. Read more about this in /webpack/dlls/README.md
+  if (process.env.WEBPACK_DLLS === '1') {
+    var manifest = loadDLLManifest(path.join(root, 'webpack/dlls/manifests/' + dllName + '.json'));
+
+    if (manifest) {
+      console.warn('Webpack: will be using the "%s" DLL.', dllName);
+
+      config.plugins.push(new webpack.DllReferencePlugin({
+        context: root,
+        manifest: manifest
+      }));
+    }
+  }
+};
+
+function loadDLLManifest(filePath) {
+  try {
+    return require(filePath);
+  }
+  catch(e) {
+    process.env.WEBPACK_DLLS = '0';
+
+    console.error(
+      function() {/*
+        ========================================================================
+        Environment Error
+        ------------------------------------------------------------------------
+        You have requested to use webpack DLLs (env var WEBPACK_DLLS=1) but a
+        manifest could not be found. This likely means you have forgotten to
+        build the DLLs.
+
+        You can do that by running:
+
+            npm run build-dlls
+
+        The request to use DLLs for this build will be ignored.
+      */}.toString().slice(15,-4)
+    );
+  }
+
+  return undefined;
+}

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -65,7 +65,8 @@ module.exports = {
       __CLIENT__: true,
       __SERVER__: false,
       __DEVELOPMENT__: false,
-      __DEVTOOLS__: false
+      __DEVTOOLS__: false,
+      __DLLS__: false,
     }),
 
     // ignore dev config

--- a/webpack/webpack-isomorphic-tools.js
+++ b/webpack/webpack-isomorphic-tools.js
@@ -4,13 +4,13 @@ var WebpackIsomorphicToolsPlugin = require('webpack-isomorphic-tools/plugin');
 // https://github.com/halt-hammerzeit/webpack-isomorphic-tools
 module.exports = {
 
-  // when adding "js" extension to asset types 
+  // when adding "js" extension to asset types
   // and then enabling debug mode, it may cause a weird error:
   //
   // [0] npm run start-prod exited with code 1
   // Sending SIGTERM to other processes..
   //
-  // debug: true, 
+  // debug: true,
 
   assets: {
     images: {
@@ -39,7 +39,7 @@ module.exports = {
     // the only place it's used is the Html.js file
     // where a <style/> tag is created with the contents of the
     // './src/theme/bootstrap.config.js' file.
-    // (the aforementioned <style/> tag can reduce the white flash 
+    // (the aforementioned <style/> tag can reduce the white flash
     //  when refreshing page in development mode)
     //
     // hooking into 'js' extension require()s isn't the best solution


### PR DESCRIPTION
This patch bases on top of the happypack one although it's not technically related (only in domain) to squeeze out some more build-time improvement. I saw the question of applying DLLs to this project asked a lot so I thought I'd contribute an answer.

Here's a table that shows the build-time gains from using DLLs first, then HappyPack + DLLs:

Elapsed (ms) | Happy | Happy Cache | Using DLLs
------------ | ----- | ----------- | ----------
9907         | No    | No          | No
7370         |       |             | Yes
6314         | Yes   |             | No
4164         |       |             | Yes
3119         |       | Yes         |

The patch may be missing a few things (the ones I know are outlined in the commit message), so feel free to rip it out yourself if you need to as it's very unlikely I'll find the time to address anything around this.

What I tested and found to be functional (you would definitely be the better judge here though):

    npm run build
    npm run dev
    npm start
    ./node_modules/.bin/webpack --config webpack/dev.config.js

The DLL is allowed in the development build only, and the code gives room to define more DLLs if you guys want later on.

Thanks.