### PR TITLE
feat(routing): Code splitting, named routes, no SSR mismatch issues

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -7,8 +7,8 @@ import ReactDOM from 'react-dom';
 import createStore from './redux/create';
 import ApiClient from './helpers/ApiClient';
 import io from 'socket.io-client';
-import {Provider} from 'react-redux';
-import { Router, browserHistory } from 'react-router';
+import { Provider } from 'react-redux';
+import { Router, browserHistory, match } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';
 import { ReduxAsyncConnect } from 'redux-async-connect';
 import useScroll from 'scroll-behavior/lib/useStandardScroll';
@@ -36,38 +36,41 @@ function initSocket() {
 
 global.socket = initSocket();
 
-const component = (
-  <Router render={(props) =>
-        <ReduxAsyncConnect {...props} helpers={{client}} filter={item => !item.deferred} />
-      } history={history}>
-    {getRoutes(store)}
-  </Router>
-);
+const routes = getRoutes(store);
+match({ history, routes: routes }, () => {
+  const component = (
+    <Router render={(props) =>
+          <ReduxAsyncConnect {...props} helpers={{client}} filter={item => !item.deferred} />
+        } history={history}>
+      {routes}
+    </Router>
+  );
 
-ReactDOM.render(
-  <Provider store={store} key="provider">
-    {component}
-  </Provider>,
-  dest
-);
-
-if (process.env.NODE_ENV !== 'production') {
-  window.React = React; // enable debugger
-
-  if (!dest || !dest.firstChild || !dest.firstChild.attributes || !dest.firstChild.attributes['data-react-checksum']) {
-    console.error('Server-side React render was discarded. Make sure that your initial render does not contain any client-side code.');
-  }
-}
-
-if (__DEVTOOLS__ && !window.devToolsExtension) {
-  const DevTools = require('./containers/DevTools/DevTools');
   ReactDOM.render(
     <Provider store={store} key="provider">
-      <div>
-        {component}
-        <DevTools />
-      </div>
+      {component}
     </Provider>,
     dest
   );
-}
+
+  if (process.env.NODE_ENV !== 'production') {
+    window.React = React; // enable debugger
+
+    if (!dest || !dest.firstChild || !dest.firstChild.attributes || !dest.firstChild.attributes['data-react-checksum']) {
+      console.error('Server-side React render was discarded. Make sure that your initial render does not contain any client-side code.');
+    }
+  }
+
+  if (__DEVTOOLS__ && !window.devToolsExtension) {
+    const DevTools = require('./containers/DevTools/DevTools');
+    ReactDOM.render(
+      <Provider store={store} key="provider">
+        <div>
+          {component}
+          <DevTools />
+        </div>
+      </Provider>,
+      dest
+    );
+  }
+});

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,17 +1,4 @@
-import React from 'react';
-import {IndexRoute, Route} from 'react-router';
 import { isLoaded as isAuthLoaded, load as loadAuth } from 'redux/modules/auth';
-import {
-    App,
-    Chat,
-    Home,
-    Widgets,
-    About,
-    Login,
-    LoginSuccess,
-    Survey,
-    NotFound,
-  } from 'containers';
 
 export default (store) => {
   const requireLogin = (nextState, replace, cb) => {
@@ -30,29 +17,92 @@ export default (store) => {
       checkAuth();
     }
   };
-
   /**
    * Please keep routes in alphabetical order
    */
-  return (
-    <Route path="/" component={App}>
-      { /* Home (main) route */ }
-      <IndexRoute component={Home}/>
+  if (typeof require.ensure !== 'function') require.ensure = (deps, cb) => cb(require);
 
-      { /* Routes requiring login */ }
-      <Route onEnter={requireLogin}>
-        <Route path="chat" component={Chat}/>
-        <Route path="loginSuccess" component={LoginSuccess}/>
-      </Route>
+  return {
+    path: '/',
+    component: require('./containers/App/App'),
+    indexRoute: {
+      component: require('./containers/Home/Home')
+    },
+    childRoutes: [{
+      path: 'login',
+      getComponent(nextState, cb) {
+        console.time('gettingComponent');
+        store.dispatch({
+          type: 'WEBPACK_LOAD'
+        });
+        require.ensure([], (require) => {
+          cb(null, require('./containers/Login/Login'));
+          store.dispatch({
+            type: 'WEBPACK_LOAD_END'
+          });
+          console.timeEnd('gettingComponent');
+        }, 'login');
+      }
 
-      { /* Routes */ }
-      <Route path="about" component={About}/>
-      <Route path="login" component={Login}/>
-      <Route path="survey" component={Survey}/>
-      <Route path="widgets" component={Widgets}/>
+    }, {
+      path: 'about',
+      getComponent(nextState, cb) {
+        console.time('gettingComponent');
+        store.dispatch({
+          type: 'WEBPACK_LOAD'
+        });
+        require.ensure([], (require) => {
+          cb(null, require('./containers/About/About'));
+          store.dispatch({
+            type: 'WEBPACK_LOAD_END'
+          });
+          console.timeEnd('gettingComponent');
+        }, 'about');
+      }
 
-      { /* Catch all route */ }
-      <Route path="*" component={NotFound} status={404} />
-    </Route>
-  );
+    }, {
+      path: 'survey',
+      getComponent(nextState, cb) {
+        require.ensure([], (require) =>
+          cb(null, require('./containers/Survey/Survey')), 'survey');
+      }
+    }, {
+      path: 'widgets',
+      getComponent(nextState, cb) {
+        store.dispatch({
+          type: 'WEBPACK_LOAD'
+        });
+        require.ensure([], (require) => {
+          cb(null, require('./containers/Widgets/Widgets'));
+          store.dispatch({
+            type: 'WEBPACK_LOAD_END'
+          });
+        }, 'widgets');
+      }
+    }, {
+      onEnter: requireLogin,
+      childRoutes: [
+        {
+          path: 'chat',
+          getComponent(nextState, cb) {
+            require.ensure([], (require) =>
+              cb(null, require('./containers/Chat/Chat')), 'chat');
+          }
+        },
+        {
+          path: 'loginSuccess',
+          getComponent(nextState, cb) {
+            require.ensure([], (require) =>
+              cb(null, require('./containers/LoginSuccess/LoginSuccess')), 'loginsuccess');
+          }
+        }
+      ]
+    }, {
+      path: '*',
+      getComponent(nextState, cb) {
+        require.ensure([], (require) =>
+          cb(null, require('./containers/NotFound/NotFound')), '404');
+      }
+    }]
+  };
 };


### PR DESCRIPTION
I reused @leifdalan's PR https://github.com/erikras/react-redux-universal-hot-example/pull/1216 to enable **code splitting** with additional features:
- named chunks (use custom names instead of numbers for chunks)
- proper matching in client's to avoid server-client rendering differences