### PR TITLE
chore(babel): remove redundant transform-react-display-name plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,8 +4,7 @@
   "plugins": [
     "transform-runtime",
     "add-module-exports",
-    "transform-decorators-legacy",
-    "transform-react-display-name"
+    "transform-decorators-legacy"
   ],
 
   "env": {


### PR DESCRIPTION
`transform-react-display-name` is already included in `babel-preset-react`:
http://babeljs.io/docs/plugins/preset-react/