### PR TITLE
2017.7.21 修改sass loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 webpack-assets.json
 webpack-stats.json
 npm-debug.log
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "karma-sourcemap-loader": "^0.3.5",
     "karma-webpack": "^1.7.0",
     "mocha": "^2.3.3",
-    "node-sass": "^3.4.2",
+    "node-sass": "^4.5.3",
     "phantomjs": "^1.9.18",
     "phantomjs-polyfill": "0.0.1",
     "react-a11y": "^0.2.6",


### PR DESCRIPTION
as for node-sass@3.4.2
It often throws an error like "404 not found".
I checked the logs and found that when I used "npm install", it went to a link "sass57" ,which did not exist at  all.There are many another ways to fix it ,such as "installing Framework 2.0" or  "installing VC2005".
But update the version should be easier.